### PR TITLE
Add Nova and Lumina agent blueprints and implementations

### DIFF
--- a/nova/agents/__init__.py
+++ b/nova/agents/__init__.py
@@ -3,11 +3,15 @@
 from .aura import AuraAgent
 from .chronos import ChronosAgent
 from .echo import EchoAgent
+from .lumina import LuminaAgent
+from .nova import NovaAgent
 from .orion import OrionAgent
 
 __all__ = [
     "AuraAgent",
     "ChronosAgent",
     "EchoAgent",
+    "LuminaAgent",
+    "NovaAgent",
     "OrionAgent",
 ]

--- a/nova/agents/lumina.py
+++ b/nova/agents/lumina.py
@@ -1,0 +1,22 @@
+"""Lumina agent implementation."""
+
+from __future__ import annotations
+
+from .base import BaseAgent
+
+
+class LuminaAgent(BaseAgent):
+    """Simulated implementation of the data and storage specialist."""
+
+    agent_type = "lumina"
+
+    def execute_task(self, task):  # type: ignore[override]
+        report = super().execute_task(task)
+        if task.name == "relational-databases":
+            report.details.append("databases: mongo and postgres provisioned")
+        elif task.name == "vector-knowledge-base":
+            report.details.append("vector-store: embeddings pipeline drafted")
+        return report
+
+
+__all__ = ["LuminaAgent"]

--- a/nova/agents/nova.py
+++ b/nova/agents/nova.py
@@ -1,0 +1,28 @@
+"""Nova chief agent implementation."""
+
+from __future__ import annotations
+
+from .base import BaseAgent
+
+
+class NovaAgent(BaseAgent):
+    """Coordinates infrastructure preparation and governance tasks."""
+
+    agent_type = "nova"
+
+    def execute_task(self, task):  # type: ignore[override]
+        report = super().execute_task(task)
+        if task.name == "infrastructure-audit":
+            report.details.append("audit: hardware baseline documented")
+        elif task.name == "container-platform":
+            report.details.append("containers: docker and kubernetes validated")
+        elif task.name == "secure-remote-access":
+            report.details.append("remote-access: vpn templates staged")
+        elif task.name == "security-audit":
+            report.details.append("security: firewall and opa review logged")
+        elif task.name == "backup-recovery":
+            report.details.append("resilience: backup runbook distributed")
+        return report
+
+
+__all__ = ["NovaAgent"]

--- a/nova/agents/registry.py
+++ b/nova/agents/registry.py
@@ -8,12 +8,14 @@ from .base import BaseAgent
 from .aura import AuraAgent
 from .chronos import ChronosAgent
 from .echo import EchoAgent
+from .lumina import LuminaAgent
+from .nova import NovaAgent
 from .orion import OrionAgent
 
 
 _REGISTRY: Dict[str, Type[BaseAgent]] = {
     agent.agent_type: agent
-    for agent in (AuraAgent, ChronosAgent, EchoAgent, OrionAgent)
+    for agent in (AuraAgent, ChronosAgent, EchoAgent, LuminaAgent, NovaAgent, OrionAgent)
 }
 
 

--- a/nova/blueprints/generator.py
+++ b/nova/blueprints/generator.py
@@ -135,10 +135,100 @@ def _build_modelops_blueprint() -> AgentBlueprint:
     )
 
 
+def _build_infrastructure_blueprint() -> AgentBlueprint:
+    return build_blueprint(
+        agent_type="nova",
+        description="Chief agent coordinating core infrastructure readiness tasks.",
+        tasks=[
+            AgentTaskSpec(
+                name="infrastructure-audit",
+                goal="Validate DGX/Spark Sophia hardware and operating system state.",
+                steps=[
+                    "Collect CPU, GPU and network adapter inventory details.",
+                    "Verify driver versions against approved compatibility matrix.",
+                    "Capture operating system tuning applied to the DGX nodes.",
+                ],
+                outputs=["Infrastructure readiness report"],
+            ),
+            AgentTaskSpec(
+                name="container-platform",
+                goal="Prepare container and orchestration tooling for deployment teams.",
+                steps=[
+                    "Check Docker installation prerequisites and runtime configuration.",
+                    "Generate Kubernetes bootstrap manifests for the control plane.",
+                    "Document post-install validation commands for operators.",
+                ],
+                outputs=["Container platform activation guide"],
+            ),
+            AgentTaskSpec(
+                name="secure-remote-access",
+                goal="Enable VPN and remote access pathways using WireGuard or OpenVPN.",
+                steps=[
+                    "Draft WireGuard and OpenVPN configuration templates.",
+                    "Outline firewall adjustments required for remote connectivity.",
+                    "Distribute credential rotation policy for remote operators.",
+                ],
+                outputs=["Remote access configuration pack"],
+            ),
+            AgentTaskSpec(
+                name="security-audit",
+                goal="Conduct security and privacy audits across the platform.",
+                steps=[
+                    "Assess firewall posture and document exposed services.",
+                    "List anti-virus and OPA policy enforcement checkpoints.",
+                    "Compile remediation recommendations for identified gaps.",
+                ],
+                outputs=["Security and privacy audit findings"],
+            ),
+            AgentTaskSpec(
+                name="backup-recovery",
+                goal="Outline data and model backup as well as recovery strategies.",
+                steps=[
+                    "Identify critical datasets and models requiring protection.",
+                    "Define backup schedules and storage retention targets.",
+                    "Publish recovery runbook including validation drills.",
+                ],
+                outputs=["Backup and recovery playbook"],
+            ),
+        ],
+    )
+
+
+def _build_data_blueprint() -> AgentBlueprint:
+    return build_blueprint(
+        agent_type="lumina",
+        description="Database and storage expert ensuring resilient data services.",
+        tasks=[
+            AgentTaskSpec(
+                name="relational-databases",
+                goal="Provision MongoDB and PostgreSQL instances for the platform.",
+                steps=[
+                    "Prepare configuration defaults for MongoDB and PostgreSQL clusters.",
+                    "Outline deployment procedures for development and production tiers.",
+                    "Record health check commands for both database engines.",
+                ],
+                outputs=["Database configuration bundle"],
+            ),
+            AgentTaskSpec(
+                name="vector-knowledge-base",
+                goal="Set up the vector store backing Sophia's knowledge base.",
+                steps=[
+                    "Compare Pinecone and FAISS deployment considerations.",
+                    "Design indexing pipeline for embeddings ingestion.",
+                    "Document query patterns and latency expectations.",
+                ],
+                outputs=["Vector store deployment guide"],
+            ),
+        ],
+    )
+
+
 _BLUEPRINT_BUILDERS: Dict[str, Callable[[], AgentBlueprint]] = {
     "aura": _build_monitoring_blueprint,
     "chronos": _build_workflow_blueprint,
     "echo": _build_avatar_blueprint,
+    "lumina": _build_data_blueprint,
+    "nova": _build_infrastructure_blueprint,
     "orion": _build_modelops_blueprint,
 }
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -3,7 +3,9 @@ from nova.blueprints.generator import create_blueprint, list_blueprints
 
 def test_blueprint_contains_tasks():
     available = list_blueprints()
-    assert {"aura", "chronos", "echo", "orion"}.issubset(set(available))
+    assert {"aura", "chronos", "echo", "lumina", "nova", "orion"}.issubset(
+        set(available)
+    )
 
     blueprint = create_blueprint("aura")
     assert blueprint.agent_type == "aura"
@@ -11,3 +13,13 @@ def test_blueprint_contains_tasks():
     first_task = blueprint.tasks[0]
     assert first_task.name == "install-grafana"
     assert first_task.steps
+
+    nova_blueprint = create_blueprint("nova")
+    assert len(nova_blueprint.tasks) == 5
+    assert nova_blueprint.tasks[0].name == "infrastructure-audit"
+
+    lumina_blueprint = create_blueprint("lumina")
+    assert {task.name for task in lumina_blueprint.tasks} == {
+        "relational-databases",
+        "vector-knowledge-base",
+    }


### PR DESCRIPTION
## Summary
- add infrastructure and data service blueprints for the Nova and Lumina roles
- implement NovaAgent and LuminaAgent with task-specific execution details and register them with the orchestrator
- extend blueprint tests to cover the new roles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53faa24a4832fb045f0a8a9abfc2e