### PR TITLE
Add communication hub and reporting for orchestrator

### DIFF
--- a/DOCS_OVERVIEW.md
+++ b/DOCS_OVERVIEW.md
@@ -11,4 +11,7 @@ This document summarises the tasks for each agent role — Nova, Orion, Lumina,
 ## Tasks List
 The file `TASKS.md` consolidates all tasks across agents into one location. Use this list to track progress and plan the implementation of Nova and its sub‑agents.
 
+## Orchestration Communication
+`docs/ORCHESTRATION_REPORTS.md` explains how the communication hub records agent messages and how Markdown status reports are produced after each orchestration run.
+
 Use these documents together to understand the project's context and to guide future development.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Nova's mission is to accelerate software delivery while improving reproducibilit
 - **Initial Setup**: Perform system checks for CPU, GPU and network, install required packages (Python, Docker, etc.), configure firewall and users.
 - **Agent Blueprints**: Autogenerate 20–30 modular agent templates with predefined roles (planner, coder, tester, ops, etc.) and assign skills.
 - **Orchestration & Monitoring**: Launch agent processes, run test simulations, monitor resource usage and automatically recover from errors.
+- **Coordinated Communication**: Built-in communication hub captures inter-agent messages and produces Markdown status reports after every orchestration run.
 - **Modularity & Portability**: All scripts and configurations are modular so the system can be migrated from a local machine to the Spark cluster.
 - **User Interfaces**: Simple command-line interface (CLI) with optional web dashboard for status and control.
 - **Logging**: Comprehensive logging and optional cloud backup of logs and configuration.

--- a/docs/ORCHESTRATION_REPORTS.md
+++ b/docs/ORCHESTRATION_REPORTS.md
@@ -1,0 +1,25 @@
+# Orchestration Communication & Reporting
+
+The Nova orchestrator now exposes a communication hub that records every
+message exchanged between agents and the orchestration engine. Each agent
+publishes a status message when a task is completed. The orchestrator
+also publishes a final notification after an agent run finishes.
+
+All recorded messages are persisted in an in-memory log that becomes part
+of the orchestration report. A Markdown summary can be generated via
+`OrchestrationReport.to_markdown()` and is automatically logged by the CLI
+(`python -m nova orchestrate`).
+
+Key capabilities:
+
+- Track per-task messages, including metadata about expected outputs and
+  warnings.
+- Filter the communication log for specific recipients, allowing agents
+  such as monitoring or workflow services to pull only relevant updates.
+- Produce Markdown summaries that can be copied into documentation or
+  shared with stakeholders after each orchestration run.
+
+This mechanism provides the foundation for richer coordination between
+Nova, Lumina, Orion, Echo, Chronos and Aura while keeping the system fully
+observable and auditable.
+

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -107,6 +107,7 @@ def run_orchestration(agent_types: Iterable[str] | None = None) -> None:
     orchestrator = Orchestrator(agent_types)
     report = orchestrator.execute()
     log_info(f"Orchestration result: {report.to_dict()}")
+    log_info("Orchestration summary (markdown):\n" + report.to_markdown())
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/nova/system/communication.py
+++ b/nova/system/communication.py
@@ -1,0 +1,115 @@
+"""Lightweight communication primitives used by the Nova orchestrator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Tuple
+
+
+@dataclass(slots=True)
+class AgentMessage:
+    """Immutable representation of an inter-agent message."""
+
+    sender: str
+    recipients: Tuple[str, ...]
+    subject: str
+    body: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sender": self.sender,
+            "recipients": list(self.recipients),
+            "subject": self.subject,
+            "body": self.body,
+            "metadata": dict(self.metadata),
+        }
+
+
+class CommunicationHub:
+    """In-memory message bus that keeps a log of agent interactions."""
+
+    def __init__(self) -> None:
+        self._messages: list[AgentMessage] = []
+
+    @staticmethod
+    def _normalise_recipients(recipients: Iterable[str] | None) -> Tuple[str, ...]:
+        if not recipients:
+            return ("orchestrator",)
+        return tuple(recipient.strip().lower() for recipient in recipients if recipient.strip())
+
+    def publish(self, message: AgentMessage) -> AgentMessage:
+        """Store ``message`` in the log and return it."""
+
+        self._messages.append(message)
+        return message
+
+    def send(
+        self,
+        *,
+        sender: str,
+        subject: str,
+        body: str,
+        recipients: Iterable[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentMessage:
+        """Create a message and persist it in the communication log."""
+
+        message = AgentMessage(
+            sender=sender.lower(),
+            recipients=self._normalise_recipients(recipients),
+            subject=subject,
+            body=body,
+            metadata=dict(metadata or {}),
+        )
+        return self.publish(message)
+
+    def broadcast(
+        self,
+        *,
+        sender: str,
+        subject: str,
+        body: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentMessage:
+        """Send a message to all recipients."""
+
+        return self.send(
+            sender=sender,
+            subject=subject,
+            body=body,
+            recipients=("all",),
+            metadata=metadata,
+        )
+
+    @property
+    def messages(self) -> Tuple[AgentMessage, ...]:
+        """Return the recorded messages as an immutable tuple."""
+
+        return tuple(self._messages)
+
+    def messages_for(self, recipient: str) -> list[AgentMessage]:
+        """Return all messages addressed to ``recipient`` or broadcast to ``all``."""
+
+        recipient_key = recipient.strip().lower()
+        return [
+            message
+            for message in self._messages
+            if "all" in message.recipients or recipient_key in message.recipients
+        ]
+
+    def latest(self) -> AgentMessage | None:
+        """Return the newest message in the log if available."""
+
+        if not self._messages:
+            return None
+        return self._messages[-1]
+
+    def clear(self) -> None:
+        """Remove all stored messages."""
+
+        self._messages.clear()
+
+
+__all__ = ["AgentMessage", "CommunicationHub"]
+

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,0 +1,26 @@
+from nova.blueprints.generator import create_blueprint
+from nova.system.communication import CommunicationHub
+from nova.agents.nova import NovaAgent
+
+
+def test_communication_hub_records_messages():
+    hub = CommunicationHub()
+    hub.send(sender="nova", subject="hello", body="world", recipients=("lumina",))
+    hub.broadcast(sender="orchestrator", subject="update", body="all good")
+    assert len(hub.messages) == 2
+    assert hub.messages_for("lumina")
+    assert hub.messages_for("orion")  # broadcast delivered to everyone
+    latest = hub.latest()
+    assert latest is not None
+    assert latest.subject == "update"
+
+
+def test_agent_emits_messages_on_task_completion():
+    blueprint = create_blueprint("nova")
+    hub = CommunicationHub()
+    agent = NovaAgent(blueprint, communication_hub=hub)
+    report = agent.execute()
+    assert report.success
+    assert hub.messages
+    subjects = {message.subject for message in hub.messages}
+    assert any(subject.startswith("task-completed::") for subject in subjects)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,11 +1,13 @@
 import os
 
+from nova.system.communication import CommunicationHub
 from nova.system.orchestrator import Orchestrator
 
 
 def test_orchestrator_executes_all_agents(tmp_path, monkeypatch):
     monkeypatch.setenv("NOVA_HOME", str(tmp_path))
-    orchestrator = Orchestrator()
+    hub = CommunicationHub()
+    orchestrator = Orchestrator(communication_hub=hub)
     report = orchestrator.execute()
     assert report.success
     assert report.agent_reports
@@ -14,3 +16,9 @@ def test_orchestrator_executes_all_agents(tmp_path, monkeypatch):
         for task_report in agent_report.task_reports:
             assert task_report.status == "completed"
             assert task_report.details
+            assert any(detail.startswith("message-sent:") for detail in task_report.details)
+    assert report.communication_log
+    assert all(message.subject.startswith("task-completed::") or message.subject.startswith("agent-run::") for message in report.communication_log)
+    markdown = report.to_markdown()
+    assert markdown.startswith("# Orchestration Report")
+    assert "## Communication Log" in markdown


### PR DESCRIPTION
## Summary
- add a communication hub module so agents and the orchestrator can exchange structured messages and log them in run reports
- extend the orchestrator and base agent implementations to emit markdown summaries and documented communication logs
- refresh the documentation and add regression tests covering the new communication hub and reporting features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54189a8b0832fb29cfff66e4573b2