### PR TITLE
Add roadmap recommendations for integration reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ python -m nova orchestrate
 - Develop agent blueprints and roles. ✅
 - Implement test harness and monitoring. ✅
 - Prepare migration to Spark hardware.
+- Schedule early integration and security reviews for each milestone to minimise rework. ⏳
+- Extend roadmap milestones with a "Definition of Done" per agent role to keep progress measurable. ⏳
+- Refine automated testing and monitoring pipelines in parallel to maintain endgame stability. ⏳
 
 ## Contributing
 

--- a/docs/IMPLEMENTATION_RECOMMENDATIONS.md
+++ b/docs/IMPLEMENTATION_RECOMMENDATIONS.md
@@ -1,0 +1,19 @@
+# Implementation Recommendations Checklist
+
+These recommendations prioritise workstreams that keep Nova's agent orchestration delivery on track. Each checklist item can be
+expanded into detailed tasks within the project management tooling.
+
+## 1. Integration & Security Reviews
+- [ ] Define integration review checkpoints for every major milestone.
+- [ ] Embed security review criteria early in the development schedule to catch risks before release candidates.
+- [ ] Assign owners for integration and security review follow-ups to prevent unresolved findings.
+
+## 2. Roadmap Milestones & Definition of Done
+- [ ] Add explicit milestones to the roadmap for each agent role (planner, coder, tester, ops, etc.).
+- [ ] Draft a "Definition of Done" per agent role that captures quality gates, documentation and handoff expectations.
+- [ ] Link each milestone to measurable metrics so progress remains auditable.
+
+## 3. Test Automation & Monitoring Stability
+- [ ] Run automated test suites in CI/CD for every orchestration update and capture trend reports.
+- [ ] Expand monitoring coverage (log aggregation, alert thresholds) to detect regressions during the final delivery phase.
+- [ ] Document incident response playbooks for late-stage stability issues.


### PR DESCRIPTION
## Summary
- extend the README roadmap with upcoming milestones for integration reviews, definitions of done, and stability workstreams
- add a dedicated checklist document that captures the recommended follow-up tasks for each area

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e546872a94832f85b8b5d3c88916ab