### PR TITLE
Add phased orchestration plan and expand agent coverage

### DIFF
--- a/DOCS_OVERVIEW.md
+++ b/DOCS_OVERVIEW.md
@@ -14,4 +14,10 @@ The file `TASKS.md` consolidates all tasks across agents into one location. Use 
 ## Orchestration Communication
 `docs/ORCHESTRATION_REPORTS.md` explains how the communication hub records agent messages and how Markdown status reports are produced after each orchestration run.
 
+## Execution Plan
+`docs/EXECUTION_PLAN.md` details the new phased execution model that aligns the orchestrator with the responsibilities captured in `TASKS.md`. Each phase lists participating agents, goals and the broadcast messages emitted during orchestration.
+
+## Task Coverage Summary
+`docs/TASK_COMPLETION.md` cross-references every requirement from `TASKS.md` with the blueprint tasks executed during orchestration to simplify auditing and reporting.
+
 Use these documents together to understand the project's context and to guide future development.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Nova's mission is to accelerate software delivery while improving reproducibilit
 - **Initial Setup**: Perform system checks for CPU, GPU and network, install required packages (Python, Docker, etc.), configure firewall and users.
 - **Agent Blueprints**: Autogenerate 20–30 modular agent templates with predefined roles (planner, coder, tester, ops, etc.) and assign skills.
 - **Orchestration & Monitoring**: Launch agent processes, run test simulations, monitor resource usage and automatically recover from errors. Runs can be executed sequentially or in parallel, depending on workload needs.
+- **Execution Plan & Phase Coordination**: The orchestrator groups Nova, Orion, Lumina, Chronos, Echo and Aura into deterministic phases. Each phase emits broadcast instructions and dependency metadata (see `docs/EXECUTION_PLAN.md`).
 - **Coordinated Communication**: Built-in communication hub captures inter-agent messages and produces Markdown status reports after every orchestration run.
 - **Automated Test Reporting**: Generate distribution-ready QA summaries via ``nova.monitoring.reports.build_markdown_test_report`` to keep stakeholders informed.
 - **Data Services Playbooks**: Ready-made deployment plans for MongoDB, PostgreSQL and vector stores live in ``docs/LUMINA_PLANS.md``.

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -1,0 +1,31 @@
+# Nova Execution Plan
+
+Nova coordinates six specialist agents across a staged execution plan. The
+plan provides deterministic ordering, clear responsibilities and explicit
+dependencies so that the orchestration engine can broadcast contextual
+instructions before every phase begins. The default phases are:
+
+1. **Foundation** – Led by Nova to validate infrastructure, container
+   platforms, remote access, security audits and backup strategies.
+2. **Model Operations** – Orion prepares the model toolchain while Chronos
+   provisions automation workflows, CI/CD, LangChain/n8n pipelines and the
+   data flywheel for continuous improvement.
+3. **Data Services** – Lumina deploys MongoDB, PostgreSQL and the vector
+   knowledge base required for Sophia.
+4. **Experience** – Echo delivers the ACE stack, Omniverse avatar pipeline
+   and Teams integration artefacts.
+5. **Observability** – Aura activates Grafana, the LUX dashboard, energy
+   optimisation insights and emotional feedback visualisations.
+
+Each phase emits a ``phase-start`` broadcast that includes a description of
+its goals and the participating agents. Agents receive ``agent-start``
+messages enriched with dependency metadata, enabling them to review prior
+phases before running their tasks. The orchestrator executes phases
+sequentially or in parallel (per phase) while maintaining a predictable
+report ordering.
+
+The CLI persists an aggregated Markdown test report with the execution plan
+under ``$NOVA_HOME/reports/nova-test-report.md`` after every orchestration
+run. This document can be shared with stakeholders to evidence that all
+tasks listed in ``TASKS.md`` are covered by the blueprints and simulated
+executions.

--- a/docs/ORCHESTRATION_REPORTS.md
+++ b/docs/ORCHESTRATION_REPORTS.md
@@ -1,10 +1,14 @@
 # Orchestration Communication & Reporting
 
-The Nova orchestrator now exposes a communication hub that records every
+The Nova orchestrator exposes a communication hub that records every
 message exchanged between agents and the orchestration engine. Each agent
 publishes a status message when a task is completed. The orchestrator
 also publishes lifecycle notifications before and after each agent run,
-ensuring that pre-run instructions are visible to the agents.
+ensuring that pre-run instructions are visible to the agents. Beginning
+with the execution-plan upgrade, phases such as *foundation*,
+*model-operations* and *observability* emit dedicated ``phase-start``
+messages so that dependent agents (for example Chronos waiting for Orion)
+receive structured context before their tasks are executed.
 
 All recorded messages are persisted in an in-memory log that becomes part
 of the orchestration report. A Markdown summary can be generated via
@@ -20,13 +24,16 @@ Key capabilities:
 - Filter the communication log for specific recipients, allowing agents
   such as monitoring or workflow services to pull only relevant updates.
 - Produce Markdown summaries that can be copied into documentation or
-  shared with stakeholders after each orchestration run.
+  shared with stakeholders after each orchestration run. The CLI now also
+  persists these reports under ``$NOVA_HOME/reports/nova-test-report.md``.
 - Run agents sequentially or in parallel by passing ``execution_mode`` to
   the orchestrator. Parallel mode uses a thread pool while maintaining
   deterministic ordering in the resulting reports.
 - Generate ready-to-share QA/test documentation via
   :func:`nova.monitoring.reports.build_markdown_test_report`, which wraps
-  the orchestration report in a stakeholder-friendly format.
+  the orchestration report in a stakeholder-friendly format. The output
+  includes the execution plan, listing the agents grouped by phase and
+  their orchestration goals for clear traceability.
 
 This mechanism provides the foundation for richer coordination between
 Nova, Lumina, Orion, Echo, Chronos and Aura while keeping the system fully

--- a/docs/TASK_COMPLETION.md
+++ b/docs/TASK_COMPLETION.md
@@ -1,0 +1,35 @@
+# Task Coverage Summary
+
+The blueprint catalogue now covers every task from `TASKS.md` through
+dedicated agent specifications. The table below lists the mapping between
+the original requirements and the blueprint task identifiers.
+
+| Agent   | TASKS.md requirement                                                | Blueprint task name             |
+|---------|---------------------------------------------------------------------|---------------------------------|
+| Nova    | DGX/Spark hardware validation                                       | `infrastructure-audit`          |
+|         | Container & orchestration tooling                                   | `container-platform`            |
+|         | Secure remote access (WireGuard/OpenVPN)                            | `secure-remote-access`          |
+|         | Security & privacy audits                                           | `security-audit`                |
+|         | Backup & recovery strategy                                          | `backup-recovery`               |
+| Orion   | Install NVIDIA NeMo                                                 | `nemo-installation`             |
+|         | Select LLM (Llama 3/Mixtral etc.)                                   | `llm-selection`                 |
+|         | Finetune LLM for Sophia                                             | `finetuning-protocol`           |
+|         | LangChain/Agent framework integration                               | `langchain-integration`         |
+| Lumina  | Install & configure MongoDB and PostgreSQL                          | `relational-databases`          |
+|         | Build vector database (Pinecone/FAISS)                              | `vector-knowledge-base`         |
+| Echo    | Install NVIDIA ACE stack (Riva, Audio2Face, NeMo)                   | `ace-toolkit-setup`             |
+|         | Avatar pipeline (Omniverse, Audio2Face, Riva)                       | `avatar-pipeline`               |
+|         | Sophia avatar integration into Teams                                | `teams-integration`             |
+| Chronos | Install & configure n8n                                             | `bootstrap-n8n`                 |
+|         | LangChain/n8n automation pipelines                                  | `agent-pipelines`               |
+|         | Data flywheel for self-improving processes                          | `data-flywheel`                 |
+|         | CI/CD pipeline with GitHub Enterprise & Kubernetes                  | `continuous-delivery`           |
+| Aura    | Install Grafana                                                     | `install-grafana`               |
+|         | Develop & integrate the LUX dashboard                               | `lux-dashboard`                 |
+|         | Optimise energy/resource efficiency                                 | `efficiency-optimisation`       |
+|         | Visualise emotional & sentiment feedback                            | `emotional-feedback-visualisation` |
+
+Running ``python -m nova orchestrate`` executes all tasks in these
+blueprints and emits a Markdown report stored at
+``$NOVA_HOME/reports/nova-test-report.md`` that documents the successful
+completion of the simulated workflows.

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from pathlib import Path
 from typing import Iterable
 
 from .agents.registry import list_agent_types
@@ -19,6 +20,7 @@ from .system.orchestrator import Orchestrator
 from .blueprints.generator import create_blueprint, list_available_blueprints
 from .monitoring.alerts import notify_info, notify_warning
 from .monitoring.logging import configure_logger, log_error, log_info, log_warning
+from .monitoring.reports import build_markdown_test_report
 
 
 DEFAULT_PACKAGES = [
@@ -110,6 +112,12 @@ def run_orchestration(agent_types: Iterable[str] | None = None) -> None:
     report = orchestrator.execute()
     log_info(f"Orchestration result: {report.to_dict()}")
     log_info("Orchestration summary (markdown):\n" + report.to_markdown())
+    report_content = build_markdown_test_report(report)
+    reports_dir = Path(os.environ.get("NOVA_HOME") or Path.cwd()) / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report_path = reports_dir / "nova-test-report.md"
+    report_path.write_text(report_content, encoding="utf-8")
+    log_info(f"Stored orchestration test report at {report_path}")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/nova/agents/aura.py
+++ b/nova/agents/aura.py
@@ -14,6 +14,10 @@ class AuraAgent(BaseAgent):
         report = super().execute_task(task)
         if task.name == "install-grafana":
             report.details.append("grafana-configured: dashboards registered")
+        elif task.name == "lux-dashboard":
+            report.details.append("lux-dashboard: executive views published")
+        elif task.name == "efficiency-optimisation":
+            report.details.append("efficiency: optimisation recommendations issued")
         elif task.name == "emotional-feedback-visualisation":
             report.details.append("sentiment-report: generated weekly digest")
         return report

--- a/nova/agents/base.py
+++ b/nova/agents/base.py
@@ -174,6 +174,7 @@ class BaseAgent:
             for message in self.communication_hub.messages_for(self.agent_type)
             if message.subject.startswith("agent-start::")
             or message.subject.startswith("orchestration-start")
+            or message.subject.startswith("phase-start::")
         ]
         for message in instructions:
             monitoring_logging.log_info(

--- a/nova/agents/chronos.py
+++ b/nova/agents/chronos.py
@@ -14,6 +14,10 @@ class ChronosAgent(BaseAgent):
             report.details.append("workflow-runner: compose manifest produced")
         elif task.name == "continuous-delivery":
             report.details.append("ci-cd: deployment artefacts registered")
+        elif task.name == "agent-pipelines":
+            report.details.append("automation: langchain and n8n flows exported")
+        elif task.name == "data-flywheel":
+            report.details.append("data-flywheel: continuous improvement loop defined")
         return report
 
 

--- a/nova/agents/echo.py
+++ b/nova/agents/echo.py
@@ -12,6 +12,8 @@ class EchoAgent(BaseAgent):
         report = super().execute_task(task)
         if task.name == "ace-toolkit-setup":
             report.details.append("ace-toolkit: readiness checklist compiled")
+        elif task.name == "avatar-pipeline":
+            report.details.append("avatar-pipeline: omniverse assets staged")
         elif task.name == "teams-integration":
             report.details.append("teams-manifest: draft stored")
         return report

--- a/nova/agents/orion.py
+++ b/nova/agents/orion.py
@@ -14,6 +14,10 @@ class OrionAgent(BaseAgent):
             report.details.append("nemo: compatibility matrix validated")
         elif task.name == "finetuning-protocol":
             report.details.append("finetuning: evaluation metrics defined")
+        elif task.name == "llm-selection":
+            report.details.append("llm-selection: candidate analysis completed")
+        elif task.name == "langchain-integration":
+            report.details.append("langchain: orchestration blueprint authored")
         return report
 
 

--- a/nova/blueprints/generator.py
+++ b/nova/blueprints/generator.py
@@ -29,6 +29,26 @@ def _build_monitoring_blueprint() -> AgentBlueprint:
                 ],
             ),
             AgentTaskSpec(
+                name="lux-dashboard",
+                goal="Deliver the Sophia LUX observability dashboard.",
+                steps=[
+                    "Design dashboard layout aligned with executive KPIs.",
+                    "Bind data sources for operational and sentiment telemetry.",
+                    "Export reusable dashboard JSON templates for reuse.",
+                ],
+                outputs=["LUX dashboard package"],
+            ),
+            AgentTaskSpec(
+                name="efficiency-optimisation",
+                goal="Optimise energy and resource usage across the platform.",
+                steps=[
+                    "Analyse recent utilisation metrics for inefficiencies.",
+                    "Propose tuning adjustments for compute and storage tiers.",
+                    "Summarise projected savings and implementation roadmap.",
+                ],
+                outputs=["Efficiency optimisation report"],
+            ),
+            AgentTaskSpec(
                 name="emotional-feedback-visualisation",
                 goal="Expose user sentiment telemetry on the monitoring stack.",
                 steps=[
@@ -73,6 +93,26 @@ def _build_workflow_blueprint() -> AgentBlueprint:
                     "Kubernetes deployment templates",
                 ],
             ),
+            AgentTaskSpec(
+                name="agent-pipelines",
+                goal="Implement LangChain and n8n pipelines for autonomous agents.",
+                steps=[
+                    "Map hand-offs between LangChain chains and Nova agents.",
+                    "Generate n8n workflow exports for key automations.",
+                    "Document monitoring hooks for each automation trigger.",
+                ],
+                outputs=["Automation pipeline exports"],
+            ),
+            AgentTaskSpec(
+                name="data-flywheel",
+                goal="Activate continuous improvement loops for training data.",
+                steps=[
+                    "Define data ingestion cadence and validation steps.",
+                    "Describe feedback incorporation into retraining schedule.",
+                    "Publish governance checklist for automated rollouts.",
+                ],
+                outputs=["Data flywheel activation brief"],
+            ),
         ],
     )
 
@@ -91,6 +131,16 @@ def _build_avatar_blueprint() -> AgentBlueprint:
                     "Produce a readiness checklist for deployment teams.",
                 ],
                 outputs=["ACE readiness checklist"],
+            ),
+            AgentTaskSpec(
+                name="avatar-pipeline",
+                goal="Establish the Omniverse and Audio2Face animation pipeline.",
+                steps=[
+                    "Generate Omniverse project scaffolding for avatar assets.",
+                    "Connect Audio2Face blend shapes with Riva speech services.",
+                    "Package deployment instructions for real-time rendering teams.",
+                ],
+                outputs=["Avatar pipeline deployment pack"],
             ),
             AgentTaskSpec(
                 name="teams-integration",
@@ -130,6 +180,26 @@ def _build_modelops_blueprint() -> AgentBlueprint:
                     "List evaluation metrics for acceptance.",
                 ],
                 outputs=["Finetuning playbook"],
+            ),
+            AgentTaskSpec(
+                name="llm-selection",
+                goal="Recommend the most suitable base LLM for Sophia.",
+                steps=[
+                    "Compare candidate LLM architectures against project KPIs.",
+                    "Capture hardware utilisation and licensing considerations.",
+                    "Record rollout decision including fallback models.",
+                ],
+                outputs=["LLM selection dossier"],
+            ),
+            AgentTaskSpec(
+                name="langchain-integration",
+                goal="Design the LangChain orchestration layer for agent hand-offs.",
+                steps=[
+                    "Identify required toolkits and callback handlers.",
+                    "Draft LangChain agent graph for Nova ecosystem workflows.",
+                    "Document deployment steps for production alignment.",
+                ],
+                outputs=["LangChain integration guide"],
             ),
         ],
     )

--- a/nova/monitoring/reports.py
+++ b/nova/monitoring/reports.py
@@ -17,6 +17,12 @@ def build_markdown_test_report(
     lines.append(f"* Overall status: {'success' if report.success else 'issues detected'}")
     lines.append(f"* Execution mode: {report.execution_mode}")
     lines.append("")
+    if report.execution_plan and report.execution_plan.phases:
+        lines.append("## Execution Plan")
+        for phase in report.execution_plan.phases:
+            lines.append(f"- **{phase.name}**: {phase.goal}")
+            lines.append("  - Agents: " + ", ".join(phase.agents))
+        lines.append("")
     lines.append("## Agent Outcomes")
     if not report.agent_reports:
         lines.append("- No agents executed.")

--- a/nova/system/mission.py
+++ b/nova/system/mission.py
@@ -1,0 +1,133 @@
+"""Execution planning utilities for the Nova orchestrator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+
+@dataclass(slots=True)
+class ExecutionPhase:
+    """Represents a logical phase within the orchestration lifecycle."""
+
+    name: str
+    goal: str
+    agents: Tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "goal": self.goal,
+            "agents": list(self.agents),
+        }
+
+
+@dataclass(slots=True)
+class ExecutionPlan:
+    """Sequence of :class:`ExecutionPhase` objects describing execution order."""
+
+    phases: Tuple[ExecutionPhase, ...]
+
+    def filtered(self, agent_types: Iterable[str]) -> "ExecutionPlan":
+        """Return a plan containing only the requested ``agent_types``.
+
+        Unknown agents are retained in an ``ad-hoc`` phase at the end of the
+        plan so that orchestrator extensions can still execute them.
+        """
+
+        sequence: List[str] = [agent.lower() for agent in agent_types]
+        if not sequence:
+            return ExecutionPlan(())
+
+        covered: set[str] = set()
+        phases: List[ExecutionPhase] = []
+        for phase in self.phases:
+            members = tuple(agent for agent in phase.agents if agent in sequence)
+            if members:
+                phases.append(
+                    ExecutionPhase(
+                        name=phase.name,
+                        goal=phase.goal,
+                        agents=members,
+                    )
+                )
+                covered.update(members)
+
+        leftovers = [agent for agent in sequence if agent not in covered]
+        if leftovers:
+            phases.append(
+                ExecutionPhase(
+                    name="ad-hoc",
+                    goal="Agents without explicit phase assignments.",
+                    agents=tuple(leftovers),
+                )
+            )
+
+        return ExecutionPlan(tuple(phases))
+
+    def iter_agents(self) -> Sequence[str]:
+        """Return the flattened execution order for the plan."""
+
+        ordered: List[str] = []
+        for phase in self.phases:
+            ordered.extend(phase.agents)
+        return tuple(ordered)
+
+    def dependencies_for(self, agent_type: str) -> Tuple[str, ...]:
+        """Return the agents that are planned to run before ``agent_type``."""
+
+        key = agent_type.lower()
+        predecessors: List[str] = []
+        for phase in self.phases:
+            if key in phase.agents:
+                for agent in phase.agents:
+                    if agent == key:
+                        break
+                    predecessors.append(agent)
+                break
+            predecessors.extend(phase.agents)
+        return tuple(predecessors)
+
+    def to_dict(self) -> dict[str, object]:
+        return {"phases": [phase.to_dict() for phase in self.phases]}
+
+
+def build_default_plan() -> ExecutionPlan:
+    """Return the default execution plan covering all built-in agents."""
+
+    phases = (
+        ExecutionPhase(
+            name="foundation",
+            goal="Prepare infrastructure, security and remote access baselines.",
+            agents=("nova",),
+        ),
+        ExecutionPhase(
+            name="model-operations",
+            goal="Provision model tooling and automation pipelines.",
+            agents=("orion", "chronos"),
+        ),
+        ExecutionPhase(
+            name="data-services",
+            goal="Bring database and vector knowledge stores online.",
+            agents=("lumina",),
+        ),
+        ExecutionPhase(
+            name="experience",
+            goal="Deliver avatar and interaction capabilities for Sophia.",
+            agents=("echo",),
+        ),
+        ExecutionPhase(
+            name="observability",
+            goal="Activate dashboards, sentiment analytics and efficiency tracking.",
+            agents=("aura",),
+        ),
+    )
+    return ExecutionPlan(phases)
+
+
+__all__ = [
+    "ExecutionPhase",
+    "ExecutionPlan",
+    "build_default_plan",
+]
+

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -23,3 +23,25 @@ def test_blueprint_contains_tasks():
         "relational-databases",
         "vector-knowledge-base",
     }
+
+    orion_tasks = {task.name for task in create_blueprint("orion").tasks}
+    assert {"nemo-installation", "finetuning-protocol", "llm-selection", "langchain-integration"}.issubset(orion_tasks)
+
+    chronos_tasks = {task.name for task in create_blueprint("chronos").tasks}
+    assert {
+        "bootstrap-n8n",
+        "continuous-delivery",
+        "agent-pipelines",
+        "data-flywheel",
+    }.issubset(chronos_tasks)
+
+    aura_tasks = {task.name for task in create_blueprint("aura").tasks}
+    assert {
+        "install-grafana",
+        "lux-dashboard",
+        "efficiency-optimisation",
+        "emotional-feedback-visualisation",
+    }.issubset(aura_tasks)
+
+    echo_tasks = {task.name for task in create_blueprint("echo").tasks}
+    assert {"ace-toolkit-setup", "avatar-pipeline", "teams-integration"}.issubset(echo_tasks)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,9 +20,13 @@ def test_cli_setup_and_orchestrate(tmp_path, monkeypatch):
     assert (tmp_path / "configs" / "settings.json").exists()
 
     __main__.main(["orchestrate"])
+    report_path = tmp_path / "reports" / "nova-test-report.md"
+    assert report_path.exists()
+    assert report_path.read_text().startswith("# Nova Integration Test Report")
 
 
 def test_cli_orchestrate_parallel(tmp_path, monkeypatch):
     monkeypatch.setenv("NOVA_HOME", str(tmp_path))
     monkeypatch.setenv("NOVA_EXECUTION_MODE", "parallel")
     __main__.main(["orchestrate"])
+    assert (tmp_path / "reports" / "nova-test-report.md").exists()

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1,0 +1,23 @@
+from nova.system.mission import ExecutionPlan, ExecutionPhase, build_default_plan
+
+
+def test_default_plan_orders_agents():
+    plan = build_default_plan()
+    filtered = plan.filtered(["nova", "orion", "lumina", "chronos", "echo", "aura"])
+    assert filtered.phases
+    assert filtered.iter_agents() == (
+        "nova",
+        "orion",
+        "chronos",
+        "lumina",
+        "echo",
+        "aura",
+    )
+    assert filtered.dependencies_for("chronos") == ("nova", "orion")
+
+
+def test_plan_retains_unknown_agents():
+    plan = ExecutionPlan((ExecutionPhase(name="custom", goal="", agents=("alpha",)),))
+    filtered = plan.filtered(["alpha", "beta"])
+    assert filtered.iter_agents() == ("alpha", "beta")
+    assert filtered.dependencies_for("beta") == ("alpha",)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -12,14 +12,22 @@ def test_orchestrator_executes_all_agents(tmp_path, monkeypatch):
     assert report.success
     assert report.agent_reports
     assert {r.agent_type for r in report.agent_reports} == set(orchestrator.agent_types)
+    assert report.execution_plan is not None
+    assert report.execution_plan.iter_agents() == tuple(orchestrator.agent_types)
     for agent_report in report.agent_reports:
         assert agent_report.pre_run_messages
+        assert any(
+            message.subject.startswith("phase-start::") or message.subject.startswith("agent-start::")
+            for message in agent_report.pre_run_messages
+        )
         for task_report in agent_report.task_reports:
             assert task_report.status == "completed"
             assert task_report.details
             assert any(detail.startswith("message-sent:") for detail in task_report.details)
     subjects = [message.subject for message in report.communication_log]
     assert "orchestration-start" in subjects
+    phase_subjects = [subject for subject in subjects if subject.startswith("phase-start::")]
+    assert phase_subjects
     for agent in orchestrator.agent_types:
         assert f"agent-start::{agent}" in subjects
         assert f"agent-run::{agent}" in subjects
@@ -27,6 +35,7 @@ def test_orchestrator_executes_all_agents(tmp_path, monkeypatch):
         subject.startswith("task-completed::")
         or subject.startswith("agent-run::")
         or subject == "orchestration-start"
+        or subject.startswith("phase-start::")
         or subject.startswith("agent-start::")
         for subject in subjects
     )
@@ -34,6 +43,7 @@ def test_orchestrator_executes_all_agents(tmp_path, monkeypatch):
     assert markdown.startswith("# Orchestration Report")
     assert "## Communication Log" in markdown
     assert "Execution mode" in markdown
+    assert "## Execution Plan" in markdown
 
 
 def test_orchestrator_parallel_execution(monkeypatch, tmp_path):
@@ -44,3 +54,4 @@ def test_orchestrator_parallel_execution(monkeypatch, tmp_path):
     assert report.success
     assert report.execution_mode == "parallel"
     assert {r.agent_type for r in report.agent_reports} == set(orchestrator.agent_types)
+    assert report.execution_plan is not None

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -18,6 +18,7 @@ def test_build_markdown_test_report(tmp_path, monkeypatch):
     assert "Overall status" in markdown
     assert "## Agent Outcomes" in markdown
     assert "## Communication Summary" in markdown
+    assert "## Execution Plan" in markdown
 
     failures = extract_failed_tasks(report)
     assert failures == []


### PR DESCRIPTION
## Summary
- add a mission planning module and update the orchestrator to execute agents per phase, emit phase instructions, and persist Markdown reports from the CLI
- extend all agent blueprints to cover every outstanding TASKS.md requirement and update agent implementations to record the richer task outputs
- document the execution plan and task coverage while expanding the automated test suite for the mission plan, orchestrator messaging, CLI reports, and monitoring summaries

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5458293d8832fae4ffb1cd7c07346