### PR TITLE
Add security audit command for Nova CLI

### DIFF
--- a/nova/system/security.py
+++ b/nova/system/security.py
@@ -1,0 +1,151 @@
+"""Security audit utilities for Nova."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Iterable, List, Tuple
+
+_TRUE_VALUES = {"1", "true", "yes", "enabled", "on"}
+_FALSE_VALUES = {"0", "false", "no", "disabled", "off"}
+
+
+@dataclass(slots=True)
+class SecurityControlStatus:
+    """Represents the status of an individual security control."""
+
+    name: str
+    status: str
+    details: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "details": self.details,
+        }
+
+
+@dataclass(slots=True)
+class SecurityAuditReport:
+    """Structured summary of a security audit run."""
+
+    controls: Tuple[SecurityControlStatus, ...]
+    findings: Tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(control.status == "ok" for control in self.controls) and not self.findings
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "passed": self.passed,
+            "controls": [control.to_dict() for control in self.controls],
+            "findings": list(self.findings),
+        }
+
+    def to_markdown(self) -> str:
+        lines: List[str] = [
+            "# Security Audit Report",
+            "",
+            f"* Overall status: {'pass' if self.passed else 'attention required'}",
+            "",
+            "## Controls",
+        ]
+        for control in self.controls:
+            lines.append(f"- **{control.name}**: {control.status} — {control.details}")
+        lines.append("")
+        lines.append("## Findings")
+        if not self.findings:
+            lines.append("- No outstanding findings.")
+        else:
+            lines.extend(f"- {finding}" for finding in self.findings)
+        return "\n".join(lines).strip()
+
+
+def _resolve_flag(value: bool | None, env_var: str) -> bool | None:
+    if value is not None:
+        return bool(value)
+    env_value = os.environ.get(env_var)
+    if env_value is None:
+        return None
+    text = env_value.strip().lower()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return None
+
+
+def _control_from_flag(
+    name: str,
+    flag: bool | None,
+    *,
+    success_detail: str,
+    failure_detail: str,
+    unknown_detail: str,
+) -> SecurityControlStatus:
+    if flag is True:
+        status = "ok"
+        details = success_detail
+    elif flag is False:
+        status = "attention"
+        details = failure_detail
+    else:
+        status = "unknown"
+        details = unknown_detail
+    return SecurityControlStatus(name=name, status=status, details=details)
+
+
+def run_security_audit(
+    *,
+    firewall_enabled: bool | None = None,
+    antivirus_enabled: bool | None = None,
+    policies_enforced: bool | None = None,
+    extra_findings: Iterable[str] | None = None,
+) -> SecurityAuditReport:
+    """Simulate a security audit across Nova's key governance controls."""
+
+    firewall_flag = _resolve_flag(firewall_enabled, "NOVA_FIREWALL_ENABLED")
+    antivirus_flag = _resolve_flag(antivirus_enabled, "NOVA_ANTIVIRUS_ENABLED")
+    policies_flag = _resolve_flag(policies_enforced, "NOVA_OPA_POLICIES_ENFORCED")
+
+    controls = (
+        _control_from_flag(
+            "Firewall",
+            firewall_flag,
+            success_detail="Firewall service enabled with logging.",
+            failure_detail="Firewall disabled or unreachable.",
+            unknown_detail="Firewall status unknown; manual verification required.",
+        ),
+        _control_from_flag(
+            "Anti-Virus",
+            antivirus_flag,
+            success_detail="Anti-virus definitions up to date.",
+            failure_detail="Anti-virus protection disabled.",
+            unknown_detail="Anti-virus status unknown; run diagnostics.",
+        ),
+        _control_from_flag(
+            "OPA Policies",
+            policies_flag,
+            success_detail="OPA policies enforced with daily rotation.",
+            failure_detail="OPA policies not enforced.",
+            unknown_detail="OPA policy enforcement unknown; review configuration.",
+        ),
+    )
+
+    findings: List[str] = []
+    for control in controls:
+        if control.status != "ok":
+            findings.append(f"{control.name}: {control.details}")
+    if extra_findings:
+        findings.extend(extra_findings)
+
+    return SecurityAuditReport(controls=controls, findings=tuple(findings))
+
+
+__all__ = [
+    "SecurityControlStatus",
+    "SecurityAuditReport",
+    "run_security_audit",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,16 @@ def test_cli_setup_and_orchestrate(tmp_path, monkeypatch):
     assert report_path.read_text().startswith("# Nova Integration Test Report")
 
 
+def test_cli_audit(monkeypatch):
+    warnings: list[str] = []
+    infos: list[str] = []
+    monkeypatch.setattr(__main__, "notify_warning", lambda message: warnings.append(message))
+    monkeypatch.setattr(__main__, "notify_info", lambda message: infos.append(message))
+    __main__.main(["audit", "--firewall", "enabled", "--antivirus", "enabled", "--policies", "disabled"])
+    assert warnings, "audit should raise warnings when a control is disabled"
+    assert not infos, "audit should not report success when warnings are issued"
+
+
 def test_cli_orchestrate_parallel(tmp_path, monkeypatch):
     monkeypatch.setenv("NOVA_HOME", str(tmp_path))
     monkeypatch.setenv("NOVA_EXECUTION_MODE", "parallel")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,34 @@
+import pytest
+
+from nova.system.security import run_security_audit
+
+
+def test_security_audit_all_controls_pass():
+    report = run_security_audit(
+        firewall_enabled=True,
+        antivirus_enabled=True,
+        policies_enforced=True,
+    )
+    assert report.passed is True
+    data = report.to_dict()
+    assert data["passed"] is True
+    assert all(control["status"] == "ok" for control in data["controls"])
+    markdown = report.to_markdown()
+    assert "Security Audit Report" in markdown
+    assert "No outstanding findings" in markdown
+
+
+def test_security_audit_collects_findings(monkeypatch):
+    monkeypatch.delenv("NOVA_FIREWALL_ENABLED", raising=False)
+    report = run_security_audit(
+        firewall_enabled=False,
+        antivirus_enabled=None,
+        policies_enforced=None,
+        extra_findings=("OPA drift detected",),
+    )
+    assert report.passed is False
+    assert "Firewall" in report.findings[0]
+    assert any("OPA drift" in finding for finding in report.findings)
+    details = report.to_dict()
+    assert details["passed"] is False
+    assert any(control["status"] != "ok" for control in details["controls"])


### PR DESCRIPTION
## Summary
- introduce a security audit workflow for Nova's CLI with a new `audit` subcommand
- implement reusable security audit reporting utilities
- expand the automated test suite to cover the audit command and report generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54b01847c832f8d1e6e14bb5f07ed