### PR TITLE
Fix orchestration markdown section heading

### DIFF
--- a/nova/system/orchestrator.py
+++ b/nova/system/orchestrator.py
@@ -56,9 +56,8 @@ class OrchestrationReport:
                 lines.append(f"- **{phase.name}**: {phase.goal}")
                 lines.append("  - Agents: " + ", ".join(phase.agents))
             lines.append("")
-        lines.extend(
-            "## Agent Runs",
-        )
+        lines.append("## Agent Runs")
+        lines.append("")
         for report in self.agent_reports:
             lines.append(report.to_markdown())
             lines.append("")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -19,6 +19,7 @@ def test_build_markdown_test_report(tmp_path, monkeypatch):
     assert "## Agent Outcomes" in markdown
     assert "## Communication Summary" in markdown
     assert "## Execution Plan" in markdown
+    assert "## Agent Runs" in report.to_markdown()
 
     failures = extract_failed_tasks(report)
     assert failures == []


### PR DESCRIPTION
## Summary
- ensure the orchestration markdown report writes the Agent Runs section as a full heading
- add a regression test that asserts the Agent Runs header is present in the markdown output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e1c7c4ac832faa39348a5b3243b9