### PR TITLE
Add CLI checklist mode for agent tasks

### DIFF
--- a/nova/system/tasks.py
+++ b/nova/system/tasks.py
@@ -29,6 +29,13 @@ class AgentTask:
 
 _DEFAULT_TASK_CSV = Path(__file__).resolve().parents[2] / "Agenten_Aufgaben_Uebersicht.csv"
 
+_COMPLETED_STATUSES = {
+    "abgeschlossen",
+    "completed",
+    "done",
+    "fertig",
+}
+
 
 def resolve_task_csv_path(csv_path: Path | str | None = None) -> Path:
     """Return the effective CSV path, considering overrides."""
@@ -147,6 +154,34 @@ def build_markdown_task_overview(tasks: Sequence[AgentTask]) -> str:
     return "\n".join(lines)
 
 
+def build_stepwise_task_checklist(tasks: Sequence[AgentTask]) -> str:
+    """Return a numbered, step-by-step checklist for ``tasks``."""
+
+    if not tasks:
+        return "# Nova Agent Task Checklist\n\nKeine Aufgaben gefunden."
+
+    grouped = group_tasks_by_agent(tasks)
+    lines: list[str] = ["# Nova Agent Task Checklist", "", f"- Gesamtanzahl Schritte: {len(tasks)}", ""]
+    step = 1
+
+    grouped_items = list(grouped.items())
+    for index, (display_name, agent_tasks) in enumerate(grouped_items):
+        lines.append(f"## {display_name}")
+        role = agent_tasks[0].agent_role
+        if role:
+            lines.append(f"*Rolle:* {role}")
+        for task in agent_tasks:
+            checkbox = "x" if task.status.strip().lower() in _COMPLETED_STATUSES else " "
+            lines.append(
+                f"{step}. [{checkbox}] {task.description} (Status: {task.status})"
+            )
+            step += 1
+        if index < len(grouped_items) - 1:
+            lines.append("")
+
+    return "\n".join(lines)
+
+
 def normalise_agent_identifier(identifier: str) -> str:
     """Normalise arbitrary agent identifier strings."""
 
@@ -161,4 +196,5 @@ __all__ = [
     "load_agent_tasks",
     "normalise_agent_identifier",
     "resolve_task_csv_path",
+    "build_stepwise_task_checklist",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,3 +58,21 @@ def test_cli_tasks_command(tmp_path, monkeypatch, caplog):
     assert "Loading agent tasks from" in caplog.text
     assert "Total tasks: 1" in caplog.text
     assert "## Nova (Chef-Agentin)" in caplog.text
+
+
+def test_cli_tasks_checklist(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),Backup,Abgeschlossen\n"
+        "Orion (KI-Software-Spezialist),LLM vorbereiten,Offen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["tasks", "--checklist"])
+
+    assert "Nova Agent Task Checklist" in caplog.text
+    assert "1. [x] Backup (Status: Abgeschlossen)" in caplog.text
+    assert "2. [ ] LLM vorbereiten (Status: Offen)" in caplog.text

--- a/tests/test_tasks_module.py
+++ b/tests/test_tasks_module.py
@@ -56,6 +56,27 @@ def test_build_markdown_with_empty_tasks():
     assert tasks.build_markdown_task_overview([]).endswith("Keine Aufgaben gefunden.")
 
 
+def test_build_stepwise_task_checklist_formats_entries():
+    entries = [
+        tasks.AgentTask("nova", "Nova (Chef-Agentin)", "Chef-Agentin", "Audit", "Offen"),
+        tasks.AgentTask(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "Backup",
+            "Abgeschlossen",
+        ),
+        tasks.AgentTask("orion", "Orion (KI-Software-Spezialist)", None, "LLM", "In Arbeit"),
+    ]
+
+    checklist = tasks.build_stepwise_task_checklist(entries)
+    assert checklist.startswith("# Nova Agent Task Checklist")
+    assert "- Gesamtanzahl Schritte: 3" in checklist
+    assert "1. [ ] Audit (Status: Offen)" in checklist
+    assert "2. [x] Backup (Status: Abgeschlossen)" in checklist
+    assert "3. [ ] LLM (Status: In Arbeit)" in checklist
+
+
 def test_load_agent_tasks_missing_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         tasks.load_agent_tasks(tmp_path / "missing.csv")


### PR DESCRIPTION
## Summary
- add a stepwise checklist renderer for agent tasks with checkbox support
- expose the checklist through `nova tasks --checklist` in the CLI
- extend unit and CLI tests to cover the new rendering mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e7731228832fa62d3d7cb675a015