### PR TITLE
Add roadmap CLI to surface phased task progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The CLI provides the following subcommands:
 - `blueprints`: list and preview the built-in agent blueprints.
 - `monitor`: initialise the logging and alerting pipeline.
 - `orchestrate`: execute every registered agent sequentially using the blueprint specifications. Provide ``--agents`` to limit the set and use ``NOVA_EXECUTION_MODE=parallel`` (or the programmatic API) for concurrent execution.
+- `tasks`: inspect agent assignments or render them as a checklist with ``--checklist``.
+- `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist.
 
 Example workflow:
 
@@ -50,6 +52,7 @@ Example workflow:
 python -m nova setup --packages docker kubernetes
 python -m nova blueprints
 python -m nova orchestrate
+python -m nova roadmap
 ```
 
 ## Task Queue & Microservices

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -22,6 +22,7 @@ from .blueprints.generator import create_blueprint, list_available_blueprints
 from .monitoring.alerts import notify_info, notify_warning
 from .monitoring.logging import configure_logger, log_error, log_info, log_warning
 from .monitoring.reports import build_markdown_test_report
+from .system.roadmap import build_phase_roadmap
 from .system.tasks import (
     build_markdown_task_overview,
     build_stepwise_task_checklist,
@@ -198,6 +199,24 @@ def run_tasks(
         log_info(line)
 
 
+def run_roadmap(csv_path: Path | None = None) -> None:
+    """Render the execution roadmap with step-by-step guidance."""
+
+    configure_logger()
+    resolved_path = resolve_task_csv_path(csv_path)
+    log_info(f"Loading agent tasks from {resolved_path}")
+
+    try:
+        tasks = load_agent_tasks(resolved_path)
+    except FileNotFoundError as exc:
+        log_error(f"Task overview file not found: {exc}")
+        raise
+
+    roadmap = build_phase_roadmap(tasks)
+    for line in roadmap.splitlines():
+        log_info(line)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the argument parser for the CLI."""
 
@@ -275,6 +294,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Render the task overview as a step-by-step checklist.",
     )
 
+    roadmap_parser = subparsers.add_parser(
+        "roadmap", help="Display the phased roadmap and remaining steps"
+    )
+    roadmap_parser.add_argument(
+        "--csv",
+        type=Path,
+        metavar="PATH",
+        help="Optional path to an alternative task overview CSV file.",
+    )
+
     return parser
 
 
@@ -301,6 +330,8 @@ def main(argv: list[str] | None = None) -> None:
             csv_path=args.csv,
             as_checklist=args.checklist,
         )
+    elif args.command == "roadmap":
+        run_roadmap(csv_path=args.csv)
     else:  # pragma: no cover - defensive default
         parser.error(f"Unknown command: {args.command}")
 

--- a/nova/system/roadmap.py
+++ b/nova/system/roadmap.py
@@ -1,0 +1,106 @@
+"""Roadmap utilities for building step-by-step execution plans."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .mission import ExecutionPhase, ExecutionPlan, build_default_plan
+from .tasks import (
+    AgentTask,
+    group_tasks_by_agent,
+    is_task_complete,
+    normalise_agent_identifier,
+)
+
+
+def _tasks_for_agents(
+    tasks: Sequence[AgentTask], agents: Iterable[str]
+) -> list[AgentTask]:
+    """Return tasks assigned to the provided ``agents``."""
+
+    agent_keys = {normalise_agent_identifier(agent) for agent in agents}
+    if not agent_keys:
+        return []
+    return [task for task in tasks if task.agent_identifier in agent_keys]
+
+
+def _render_pending_steps(pending: Sequence[AgentTask]) -> list[str]:
+    if not pending:
+        return []
+
+    lines: list[str] = ["### Schritt-für-Schritt"]
+    grouped = group_tasks_by_agent(pending)
+    step = 1
+    for display_name, agent_tasks in grouped.items():
+        lines.append(f"#### {display_name}")
+        role = agent_tasks[0].agent_role
+        if role:
+            lines.append(f"*Rolle:* {role}")
+        for task in agent_tasks:
+            lines.append(f"{step}. [ ] {task.description} (Status: {task.status})")
+            step += 1
+        lines.append("")
+    return lines
+
+
+def _render_phase_section(phase: ExecutionPhase, tasks: Sequence[AgentTask]) -> list[str]:
+    section: list[str] = [
+        f"## {phase.name.title()}",
+        phase.goal,
+    ]
+    if phase.agents:
+        section.append("*Agenten:* " + ", ".join(phase.agents))
+
+    phase_tasks = _tasks_for_agents(tasks, phase.agents)
+    total = len(phase_tasks)
+    completed = sum(1 for task in phase_tasks if is_task_complete(task.status))
+    percent = int(round((completed / total) * 100)) if total else 0
+    section.append(f"*Fortschritt:* {completed}/{total} ({percent}%)")
+
+    if not total:
+        section.append("*Hinweis:* Für diese Phase sind noch keine Aufgaben im CSV hinterlegt.")
+        section.append("")
+        return section
+
+    pending = [task for task in phase_tasks if not is_task_complete(task.status)]
+    if not pending:
+        section.append("Alle Schritte abgeschlossen. ✅")
+        section.append("")
+        return section
+
+    section.append("")
+    section.extend(_render_pending_steps(pending))
+    return section
+
+
+def build_phase_roadmap(
+    tasks: Sequence[AgentTask], plan: ExecutionPlan | None = None
+) -> str:
+    """Render a Markdown roadmap outlining the remaining steps per phase."""
+
+    effective_plan = plan or build_default_plan()
+
+    total_tasks = len(tasks)
+    completed_tasks = sum(1 for task in tasks if is_task_complete(task.status))
+
+    lines: list[str] = [
+        "# Nova Phasen-Roadmap",
+        "",
+        f"- Gesamtaufgaben: {total_tasks}",
+        f"- Abgeschlossen: {completed_tasks}",
+        f"- Offen: {total_tasks - completed_tasks}",
+        "",
+    ]
+
+    if not effective_plan.phases:
+        lines.append("Keine Phasen definiert.")
+        return "\n".join(lines).strip()
+
+    for phase in effective_plan.phases:
+        lines.extend(_render_phase_section(phase, tasks))
+
+    return "\n".join(lines).rstrip()
+
+
+__all__ = ["build_phase_roadmap"]
+

--- a/nova/system/tasks.py
+++ b/nova/system/tasks.py
@@ -37,6 +37,12 @@ _COMPLETED_STATUSES = {
 }
 
 
+def is_task_complete(status: str) -> bool:
+    """Return ``True`` if ``status`` represents a completed task."""
+
+    return status.strip().lower() in _COMPLETED_STATUSES
+
+
 def resolve_task_csv_path(csv_path: Path | str | None = None) -> Path:
     """Return the effective CSV path, considering overrides."""
 
@@ -171,7 +177,7 @@ def build_stepwise_task_checklist(tasks: Sequence[AgentTask]) -> str:
         if role:
             lines.append(f"*Rolle:* {role}")
         for task in agent_tasks:
-            checkbox = "x" if task.status.strip().lower() in _COMPLETED_STATUSES else " "
+            checkbox = "x" if is_task_complete(task.status) else " "
             lines.append(
                 f"{step}. [{checkbox}] {task.description} (Status: {task.status})"
             )
@@ -193,6 +199,7 @@ __all__ = [
     "build_markdown_task_overview",
     "filter_tasks",
     "group_tasks_by_agent",
+    "is_task_complete",
     "load_agent_tasks",
     "normalise_agent_identifier",
     "resolve_task_csv_path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,3 +76,19 @@ def test_cli_tasks_checklist(tmp_path, monkeypatch, caplog):
     assert "Nova Agent Task Checklist" in caplog.text
     assert "1. [x] Backup (Status: Abgeschlossen)" in caplog.text
     assert "2. [ ] LLM vorbereiten (Status: Offen)" in caplog.text
+
+
+def test_cli_roadmap_command(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),System prüfen,Offen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["roadmap"])
+
+    assert "Nova Phasen-Roadmap" in caplog.text
+    assert "System prüfen" in caplog.text

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -1,0 +1,49 @@
+from nova.system.mission import build_default_plan
+from nova.system.roadmap import build_phase_roadmap
+from nova.system.tasks import AgentTask
+
+
+def _sample_tasks() -> list[AgentTask]:
+    return [
+        AgentTask(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "System prüfen",
+            "Offen",
+        ),
+        AgentTask(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "Backup einrichten",
+            "Abgeschlossen",
+        ),
+        AgentTask(
+            "orion",
+            "Orion (KI-Software-Spezialist)",
+            "KI-Software-Spezialist",
+            "LLM vorbereiten",
+            "In Arbeit",
+        ),
+    ]
+
+
+def test_build_phase_roadmap_highlights_pending_steps():
+    plan = build_default_plan()
+    roadmap = build_phase_roadmap(_sample_tasks(), plan)
+
+    assert "# Nova Phasen-Roadmap" in roadmap
+    assert "## Foundation" in roadmap
+    assert "*Fortschritt:* 1/2 (50%)" in roadmap
+    assert "1. [ ] System prüfen (Status: Offen)" in roadmap
+    assert "LLM vorbereiten" in roadmap
+
+
+def test_build_phase_roadmap_handles_empty_phases():
+    plan = build_default_plan()
+    roadmap = build_phase_roadmap([], plan)
+
+    assert "- Gesamtaufgaben: 0" in roadmap
+    assert "Keine Phasen definiert." not in roadmap
+    assert "*Hinweis:* Für diese Phase" in roadmap

--- a/tests/test_tasks_module.py
+++ b/tests/test_tasks_module.py
@@ -10,6 +10,12 @@ def test_resolve_task_csv_path_env_override(monkeypatch, tmp_path):
     assert resolved == csv_path
 
 
+def test_is_task_complete_handles_various_labels():
+    assert tasks.is_task_complete("Abgeschlossen")
+    assert tasks.is_task_complete("completed")
+    assert not tasks.is_task_complete("Offen")
+
+
 def test_load_agent_tasks_reads_rows(tmp_path):
     csv_path = tmp_path / "tasks.csv"
     csv_path.write_text(


### PR DESCRIPTION
## Summary
- add roadmap utilities to aggregate agent tasks by execution phase and render a stepwise roadmap
- expose a task completion helper, extend CLI with a `roadmap` command, and update documentation
- cover the new behaviour with roadmap unit tests and CLI integration checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e946a988832f861c66ec1430af46