### PR TITLE
Add CLI phase filtering to roadmap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The CLI provides the following subcommands:
 - `monitor`: initialise the logging and alerting pipeline.
 - `orchestrate`: execute every registered agent sequentially using the blueprint specifications. Provide ``--agents`` to limit the set and use ``NOVA_EXECUTION_MODE=parallel`` (or the programmatic API) for concurrent execution.
 - `tasks`: inspect agent assignments or render them as a checklist with ``--checklist``.
-- `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist.
+- `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist. Pass `--phase foundation observability` to focus on specific phases.
 
 Example workflow:
 

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -199,7 +199,7 @@ def run_tasks(
         log_info(line)
 
 
-def run_roadmap(csv_path: Path | None = None) -> None:
+def run_roadmap(csv_path: Path | None = None, phases: Iterable[str] | None = None) -> None:
     """Render the execution roadmap with step-by-step guidance."""
 
     configure_logger()
@@ -212,7 +212,7 @@ def run_roadmap(csv_path: Path | None = None) -> None:
         log_error(f"Task overview file not found: {exc}")
         raise
 
-    roadmap = build_phase_roadmap(tasks)
+    roadmap = build_phase_roadmap(tasks, phase_filters=phases)
     for line in roadmap.splitlines():
         log_info(line)
 
@@ -303,6 +303,12 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Optional path to an alternative task overview CSV file.",
     )
+    roadmap_parser.add_argument(
+        "--phase",
+        nargs="*",
+        metavar="PHASE",
+        help="Limit the roadmap to the specified phases (e.g. foundation).",
+    )
 
     return parser
 
@@ -331,7 +337,7 @@ def main(argv: list[str] | None = None) -> None:
             as_checklist=args.checklist,
         )
     elif args.command == "roadmap":
-        run_roadmap(csv_path=args.csv)
+        run_roadmap(csv_path=args.csv, phases=args.phase)
     else:  # pragma: no cover - defensive default
         parser.error(f"Unknown command: {args.command}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,3 +92,22 @@ def test_cli_roadmap_command(tmp_path, monkeypatch, caplog):
 
     assert "Nova Phasen-Roadmap" in caplog.text
     assert "System prüfen" in caplog.text
+
+
+def test_cli_roadmap_with_phase_filter(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),System prüfen,Offen\n"
+        "Aura (Monitoring & Dashboard-Entwicklerin),Grafana installieren,Offen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["roadmap", "--phase", "observability"])
+
+    assert "*Gefiltert nach Phasen:* observability" in caplog.text
+    assert "## Observability" in caplog.text
+    assert "Grafana installieren" in caplog.text
+    assert "## Foundation" not in caplog.text

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -47,3 +47,28 @@ def test_build_phase_roadmap_handles_empty_phases():
     assert "- Gesamtaufgaben: 0" in roadmap
     assert "Keine Phasen definiert." not in roadmap
     assert "*Hinweis:* Für diese Phase" in roadmap
+
+
+def test_build_phase_roadmap_filters_to_requested_phase():
+    plan = build_default_plan()
+    roadmap = build_phase_roadmap(
+        _sample_tasks(),
+        plan,
+        phase_filters=["model-operations"],
+    )
+
+    assert "## Foundation" not in roadmap
+    assert "## Model-Operations" in roadmap
+    assert "1. [ ] LLM vorbereiten (Status: In Arbeit)" in roadmap
+    assert "*Gefiltert nach Phasen:* model-operations" in roadmap
+
+
+def test_build_phase_roadmap_warns_on_unknown_phase():
+    plan = build_default_plan()
+    roadmap = build_phase_roadmap(
+        _sample_tasks(),
+        plan,
+        phase_filters=["unbekannt"],
+    )
+
+    assert "Keine der angeforderten Phasen" in roadmap


### PR DESCRIPTION
## Summary
- add optional phase filters to the roadmap builder so teams can focus on targeted execution stages
- expose the new filtering capability through the CLI `roadmap` command and document the flag in the README
- expand roadmap unit tests and CLI integration tests to cover filtered output and unknown phases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5eb18a6e4832f931d0c97b32a5597