### PR TITLE
Add progress report based on roadmap status

### DIFF
--- a/progress_report.md
+++ b/progress_report.md
@@ -1,0 +1,8 @@
+# Progress Report
+
+Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 2 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 29 %.
+
+- Abgeschlossen: "Develop agent blueprints and roles", "Implement test harness and monitoring".
+- Offen: Fünf weitere Roadmap-Punkte, darunter das Finalisieren der Feature-Liste für v1.0 und diverse Integrations- und Verbesserungsaufgaben.
+
+Dieser Wert ist eine grobe Näherung, weil keine detaillierteren Statusangaben im Repository vorliegen.


### PR DESCRIPTION
## Summary
- add a progress report that translates the README roadmap status into a percentage estimate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ed8cae54832fa2fecc09c7c7d2cf