### PR TITLE
Add CLI support for next-step task summaries

### DIFF
--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -22,7 +22,7 @@ from .blueprints.generator import create_blueprint, list_available_blueprints
 from .monitoring.alerts import notify_info, notify_warning
 from .monitoring.logging import configure_logger, log_error, log_info, log_warning
 from .monitoring.reports import build_markdown_test_report
-from .system.roadmap import build_phase_roadmap
+from .system.roadmap import build_next_steps_summary, build_phase_roadmap
 from .system.tasks import (
     build_markdown_task_overview,
     build_stepwise_task_checklist,
@@ -217,6 +217,28 @@ def run_roadmap(csv_path: Path | None = None, phases: Iterable[str] | None = Non
         log_info(line)
 
 
+def run_next_steps(
+    csv_path: Path | None = None,
+    *,
+    limit_per_agent: int = 1,
+) -> None:
+    """Render the next-step summary derived from pending tasks."""
+
+    configure_logger()
+    resolved_path = resolve_task_csv_path(csv_path)
+    log_info(f"Loading agent tasks from {resolved_path}")
+
+    try:
+        tasks = load_agent_tasks(resolved_path)
+    except FileNotFoundError as exc:
+        log_error(f"Task overview file not found: {exc}")
+        raise
+
+    summary = build_next_steps_summary(tasks, limit_per_agent=limit_per_agent)
+    for line in summary.splitlines():
+        log_info(line)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the argument parser for the CLI."""
 
@@ -310,6 +332,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Limit the roadmap to the specified phases (e.g. foundation).",
     )
 
+    next_steps_parser = subparsers.add_parser(
+        "next-steps",
+        help="Display the next pending steps per agent",
+    )
+    next_steps_parser.add_argument(
+        "--csv",
+        type=Path,
+        metavar="PATH",
+        help="Optional path to an alternative task overview CSV file.",
+    )
+    next_steps_parser.add_argument(
+        "--limit",
+        type=int,
+        metavar="N",
+        default=1,
+        help="Number of steps to show per agent (use 0 for unlimited).",
+    )
+
     return parser
 
 
@@ -338,6 +378,8 @@ def main(argv: list[str] | None = None) -> None:
         )
     elif args.command == "roadmap":
         run_roadmap(csv_path=args.csv, phases=args.phase)
+    elif args.command == "next-steps":
+        run_next_steps(csv_path=args.csv, limit_per_agent=args.limit)
     else:  # pragma: no cover - defensive default
         parser.error(f"Unknown command: {args.command}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from nova import __main__
     [
         ["blueprints"],
         ["monitor"],
+        ["next-steps"],
     ],
 )
 def test_cli_commands(argv):
@@ -111,3 +112,24 @@ def test_cli_roadmap_with_phase_filter(tmp_path, monkeypatch, caplog):
     assert "## Observability" in caplog.text
     assert "Grafana installieren" in caplog.text
     assert "## Foundation" not in caplog.text
+
+
+def test_cli_next_steps_command(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),System prüfen,Offen\n"
+        "Nova (Chef-Agentin),Backup,In Arbeit\n"
+        "Chronos (Workflow & Automation Specialist),n8n Workflows,Offen\n"
+        "Orion (KI-Software-Spezialist),LLM vorbereiten,Abgeschlossen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["next-steps", "--limit", "1"])
+
+    assert "Nova Nächste Schritte" in caplog.text
+    assert "System prüfen" in caplog.text
+    assert "… 1 weitere Aufgabe" in caplog.text
+    assert "n8n Workflows" in caplog.text

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -1,5 +1,5 @@
 from nova.system.mission import build_default_plan
-from nova.system.roadmap import build_phase_roadmap
+from nova.system.roadmap import build_next_steps_summary, build_phase_roadmap
 from nova.system.tasks import AgentTask
 
 
@@ -72,3 +72,74 @@ def test_build_phase_roadmap_warns_on_unknown_phase():
     )
 
     assert "Keine der angeforderten Phasen" in roadmap
+
+
+def test_build_next_steps_summary_groups_by_phase_and_limit():
+    plan = build_default_plan()
+    tasks = [
+        AgentTask("nova", "Nova (Chef-Agentin)", "Chef-Agentin", "System prüfen", "Offen"),
+        AgentTask(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "Backup einrichten",
+            "In Arbeit",
+        ),
+        AgentTask(
+            "orion",
+            "Orion (KI-Software-Spezialist)",
+            "KI-Software-Spezialist",
+            "LLM vorbereiten",
+            "In Arbeit",
+        ),
+        AgentTask(
+            "chronos",
+            "Chronos (Workflow & Automation Specialist)",
+            "Workflow & Automation Specialist",
+            "n8n Workflows aufsetzen",
+            "Offen",
+        ),
+        AgentTask(
+            "zeus",
+            "Zeus",
+            None,
+            "Sonstige Abstimmungen",
+            "Offen",
+        ),
+        AgentTask(
+            "echo",
+            "Echo",
+            "Avatar & Interaction Designer",
+            "Avatar Demo",
+            "Abgeschlossen",
+        ),
+    ]
+
+    summary = build_next_steps_summary(tasks, plan, limit_per_agent=1)
+
+    assert "# Nova Nächste Schritte" in summary
+    assert "- Offene Aufgaben gesamt: 5" in summary
+    assert "## Foundation" in summary and "System prüfen" in summary
+    assert "- … 1 weitere Aufgabe" in summary
+    assert "## Model-Operations" in summary
+    assert "n8n Workflows aufsetzen" in summary
+    assert "## Ad-Hoc" in summary
+    assert "Zeus" in summary
+    assert "Backup einrichten" not in summary
+
+
+def test_build_next_steps_summary_reports_completion():
+    plan = build_default_plan()
+    tasks = [
+        AgentTask(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "System prüfen",
+            "Abgeschlossen",
+        )
+    ]
+
+    summary = build_next_steps_summary(tasks, plan)
+
+    assert summary.strip().endswith("Alle Aufgaben abgeschlossen. ✅")


### PR DESCRIPTION
## Summary
- add a `build_next_steps_summary` helper that groups pending agent tasks by phase and highlights the next actionable steps
- expose the summary through a new `python -m nova next-steps` CLI command with a limit flag for per-agent items
- cover the new behaviour with roadmap and CLI tests including parameterised smoke coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5ed742b1c832f91f4c5ce51430d08