### PR TITLE
Add v1.0 feature catalogue and refresh roadmap progress

### DIFF
--- a/DOCS_OVERVIEW.md
+++ b/DOCS_OVERVIEW.md
@@ -11,6 +11,9 @@ This document summarises the tasks for each agent role — Nova, Orion, Lumina,
 ## Tasks List
 The file `TASKS.md` consolidates all tasks across agents into one location. Use this list to track progress and plan the implementation of Nova and its sub‑agents.
 
+## v1.0 Feature Catalogue
+`docs/v1_feature_list.md` captures the scoped feature set, owners and acceptance criteria for the v1.0 release. It serves as the reference when updating the roadmap and validating Definition-of-Done per agent role.
+
 ## Orchestration Communication
 `docs/ORCHESTRATION_REPORTS.md` explains how the communication hub records agent messages and how Markdown status reports are produced after each orchestration run.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python -m nova roadmap
 
 ## Roadmap
 
-- Finalise feature list for v1.0.
+- Finalise feature list for v1.0. ✅ (See `docs/v1_feature_list.md`.)
 - Develop agent blueprints and roles. ✅
 - Implement test harness and monitoring. ✅
 - Prepare migration to Spark hardware.

--- a/docs/v1_feature_list.md
+++ b/docs/v1_feature_list.md
@@ -1,0 +1,67 @@
+# Meta-Agent Nova v1.0 Feature List
+
+This catalogue defines the functional scope for the v1.0 release of the Nova orchestration stack. It links the roadmap priorities to concrete, testable outcomes per agent role so the team can plan delivery, QA and release sign-off with shared expectations.
+
+## Release Objectives
+- Deliver an end-to-end orchestration workflow that prepares infrastructure, deploys the AI stack and exposes operational monitoring for Sophia.
+- Ensure every specialist agent contributes production-ready artefacts with clear ownership and auditable acceptance criteria.
+- Provide the governance hooks (security, compliance, rollback) needed to deploy safely onto Spark hardware.
+
+## Feature Catalogue
+
+### 1. Infrastructure & Governance Foundation (Nova)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| DGX/Spark Readiness Audits | Run scripted hardware, OS and network diagnostics with Markdown evidence artefacts. | Nova | Reports stored under `reports/hw/` covering CPU, GPU, fabric and firmware deltas; checklist signed off in repository. |
+| Container Platform Baseline | Automated installation validation for Docker and Kubernetes including policy bootstrap. | Nova | CI run of `python -m nova system.check_containers` succeeds; kubeconfig and Docker daemon health logs archived. |
+| Secure Remote Access Profiles | WireGuard/OpenVPN templates with least-privilege configs and onboarding guide. | Nova | Sample configs committed under `nova/security/vpn/`; onboarding playbook reviewed by security officer. |
+| Security & Compliance Audit Trail | Firewall, OPA and kill-switch policies codified with audit logging enabled. | Nova | `nova/security` policies compiled without errors; mock incident drill recorded in `reports/security/incident-sim.md`. |
+| Resilient Backup & Recovery | Scheduled backup scripts plus recovery rehearsal covering configuration and state. | Nova | Dry-run restore documented with timestamps; backup jobs registered in orchestrator schedule. |
+
+### 2. Model Operations Platform (Orion)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| NeMo Toolchain Provisioning | Reproducible NeMo install scripts with dependency pinning. | Orion | Installer passes smoke tests on CI runner; version matrix captured in `docs/model_stack.md`. |
+| LLM Baseline Deployment | Reference deployment of chosen LLM (Llama 3 or Mixtral) with resource sizing guidance. | Orion | Deployment manifest stored in `deploy/model/`; load test summary shows <150 ms token latency on staging GPU. |
+| Finetuning Workflow Blueprint | SOP for data selection, evaluation metrics and automated retraining triggers. | Orion | Workflow diagram committed; `make finetune-dryrun` executes evaluation stubs successfully. |
+| LangChain Integration Layer | Orchestrated agent interfaces for query routing and tool invocation. | Orion | Integration tests in `tests/test_langchain_integration.py` pass; API schema documented in README appendix. |
+
+### 3. Data & Knowledge Services (Lumina)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| Managed MongoDB/PostgreSQL Stack | Infrastructure-as-code recipes for transactional storage. | Lumina | Helm/chart or Terraform plans validated; connection health checks logged in deployment report. |
+| Vector Knowledge Base | Configurable FAISS/Pinecone module for semantic search with sync jobs. | Lumina | `nova/task_queue` integration test returns relevant embeddings in <200 ms; indexing runbook documented. |
+| Data Governance & Retention | Policies for data retention, encryption and GDPR alignment. | Lumina | Policy document approved; automated retention tests succeed for sample datasets. |
+
+### 4. Interaction & Experience Layer (Echo)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| ACE Stack Enablement | Installable Riva, Audio2Face and NeMo assets with compatibility verification. | Echo | Compatibility matrix published; smoke test uses sample utterance to round-trip audio → text → audio. |
+| Avatar Production Pipeline | Omniverse → Audio2Face → Riva workflow with asset management. | Echo | Pipeline script renders sample avatar with documented asset repository structure. |
+| Enterprise Communications Bridge | Microsoft Teams (or alt) integration with auth and compliance notes. | Echo | Prototype bot registered; integration checklist approved by IT security. |
+
+### 5. Workflow Automation & Delivery (Chronos)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| n8n Automation Hub | Containerised n8n deployment templates with baseline workflows. | Chronos | `docker compose up n8n` succeeds locally; sample workflow file synced to repo. |
+| Agent Workflow Orchestration | LangChain ↔ n8n bridge enabling cross-agent tasks with status callbacks. | Chronos | Integration test demonstrates task handoff; status updates visible in orchestrator logs. |
+| CI/CD Release Train | GitHub Enterprise + Kubernetes pipeline with gated approvals. | Chronos | CI pipeline definition committed; staging deployment triggered via GitHub Actions. |
+| Data Flywheel Automation | Scheduled retraining/data refresh cycles capturing telemetry for continuous improvement. | Chronos | Cron workflow documented; telemetry stored in monitoring stack for two consecutive cycles. |
+
+### 6. Monitoring & Insights (Aura)
+| Feature | Description | Owner | Acceptance Criteria |
+| --- | --- | --- | --- |
+| Grafana Observability Suite | Grafana deployment with Prometheus data sources and alert rules. | Aura | Dashboard JSON exported to repo; alerts tested using simulated incident script. |
+| LUX Experience Dashboard | UX dashboards combining operational KPIs, sentiment and avatar telemetry. | Aura | Figma (or equivalent) mockups linked; Grafana panels demonstrate KPI overlays. |
+| Efficiency & Sustainability Metrics | Energy/resource tracking with optimisation recommendations. | Aura | KPI definitions documented; efficiency report generated from staged workloads. |
+| Sentiment & Emotion Visualisation | Real-time display of user sentiment across sessions. | Aura | Sample dataset visualised; API contract defined for ingestion from interaction layer. |
+
+## Release Management Enablers
+- **Definition of Done Alignment:** Each feature references measurable artefacts (scripts, documents, dashboards) to plug into roadmap DoD updates.
+- **Security & Compliance Hooks:** All agents feed into the audit trail to satisfy governance checkpoints ahead of Spark migration.
+- **Testing Expectations:** Unit/integration tests plus smoke validations are linked to CI to uphold the "Implement test harness and monitoring" milestone.
+
+## Next Actions
+1. Map features to milestones in the project board and assign owners per agent.
+2. Update roadmap checkmarks once acceptance criteria are verified through working demos or documentation.
+3. Use this catalogue as the baseline for release readiness reviews prior to Spark hardware migration.

--- a/progress_report.md
+++ b/progress_report.md
@@ -1,8 +1,8 @@
 # Progress Report
 
-Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 2 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 29 %.
+Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 3 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 43 %.
 
-- Abgeschlossen: "Develop agent blueprints and roles", "Implement test harness and monitoring".
-- Offen: Fünf weitere Roadmap-Punkte, darunter das Finalisieren der Feature-Liste für v1.0 und diverse Integrations- und Verbesserungsaufgaben.
+- Abgeschlossen: "Finalise feature list for v1.0", "Develop agent blueprints and roles", "Implement test harness and monitoring".
+- Offen: Vier weitere Roadmap-Punkte, darunter die Migration zur Spark-Hardware sowie Integrations-, Sicherheits- und Testautomatisierungsaufgaben.
 
 Dieser Wert ist eine grobe Näherung, weil keine detaillierteren Statusangaben im Repository vorliegen.


### PR DESCRIPTION
## Summary
- add a v1.0 feature list document detailing scope, owners, and acceptance criteria per agent role
- link the new catalogue from the README roadmap and docs overview
- update the progress report to reflect the completed roadmap milestone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f20b63b8832f96bbb9e276d0901e