### PR TITLE
Add per-agent definition of done documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ python -m nova roadmap
 - Implement test harness and monitoring. ✅
 - Prepare migration to Spark hardware. 🚧 (See `docs/SPARK_MIGRATION_PLAN.md`.)
 - Schedule early integration and security reviews for each milestone to minimise rework. ⏳
-- Extend roadmap milestones with a "Definition of Done" per agent role to keep progress measurable. ⏳
+- Extend roadmap milestones with a "Definition of Done" per agent role to keep progress measurable. ✅ (See `docs/DEFINITION_OF_DONE.md`.)
 - Refine automated testing and monitoring pipelines in parallel to maintain endgame stability. ⏳
 
 ## Contributing

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -1,0 +1,53 @@
+# Definition of Done je Agentenrolle
+
+Dieses Dokument konkretisiert die Qualitätskriterien, die erfüllt sein müssen, damit eine Agentenrolle als "done" gilt. Die Checklisten basieren auf den Aufgaben aus `TASKS.md`, dem v1.0 Feature-Katalog und den Roadmap-Meilensteinen.
+
+## Gemeinsame Qualitätskriterien
+- [ ] Dokumentation im Repository verlinkt (Readme, Playbooks, Automationsskripte).
+- [ ] Automatisierte Tests oder Validierungsskripte für kritische Pfade vorhanden und ausgeführt.
+- [ ] Sicherheits-, Logging- und Monitoring-Hooks aktiviert bzw. dokumentiert.
+- [ ] Übergabeprotokoll mit Betriebs- bzw. Runbook-Hinweisen liegt vor.
+
+## Nova – Chef-Agentin
+- [ ] Hardware- und Systemaudits (CPU, GPU, Netzwerk, Speicher) dokumentiert, inkl. Pass/Fail-Report.
+- [ ] Container- und Orchestrierungstools (Docker, Kubernetes) installiert, Versionen erfasst und Smoke-Test durchgeführt.
+- [ ] VPN/Remote-Zugriff (WireGuard oder OpenVPN) konfiguriert, Zugangsdaten sicher abgelegt, Verbindungstest protokolliert.
+- [ ] Sicherheits- und Backup-Strategie aktiv, inkl. Firewall-/OPA-Policies und Wiederherstellungsplan.
+- [ ] `nova setup` Befehl bzw. Skripte liefern reproduzierbare Ergebnisse (CI-Check oder lokaler Dry-Run).
+
+## Orion – KI-Software-Spezialist
+- [ ] NVIDIA NeMo Installationsablauf dokumentiert, Abhängigkeiten geprüft (z. B. CUDA, cuDNN).
+- [ ] Referenz-LLM bereitgestellt (z. B. Llama 3 oder Mixtral) mit Ressourcenprofil und Deployment-Beschreibung.
+- [ ] Fine-Tuning-Konzept mit Datenschema, Evaluationsmetriken und Automatisierungspfad verabschiedet.
+- [ ] LangChain/Agentframework-Integration nachgewiesen (Smoke-Test oder Beispielworkflow im Repository).
+- [ ] Sicherheits- und Compliance-Aspekte (Lizenzierung, Datennutzung) bewertet und dokumentiert.
+
+## Lumina – Database & Storage Expert
+- [ ] MongoDB- und PostgreSQL-Deployments beschrieben (Installationsskripte oder Helm-Charts vorhanden).
+- [ ] Backup- und Restore-Prozeduren für beide Datenbanken getestet und dokumentiert.
+- [ ] Vektor-Datenbank (Pinecone, FAISS o. Ä.) ausgewählt, Benchmark-Ergebnisse und Integrationsschnittstelle vorhanden.
+- [ ] Zugriffskontrollen (Benutzer, Rollen, Secrets) eingerichtet und überprüft.
+- [ ] Monitoring- und Alerting-Checks für Datenbanken in Grafana/Prometheus integriert.
+
+## Echo – Avatar & Interaction Designer
+- [ ] NVIDIA ACE-Komponenten (Riva, Audio2Face, NeMo) installiert, Kompatibilität getestet.
+- [ ] Avatar-Pipeline vom Modell bis zur Ausspielung dokumentiert (Sequenzdiagramm + Konfigurationsdateien).
+- [ ] Animations- und Audioqualität anhand definierter KPIs gemessen (Latenz, FPS, Audio-Clarity).
+- [ ] Integration in ausgewählte Kommunikationsplattform (z. B. Microsoft Teams) prototypisch umgesetzt.
+- [ ] Datenschutz- und Content-Richtlinien für Audio/Video-Streams dokumentiert und abgenommen.
+
+## Chronos – Workflow & Automation Specialist
+- [ ] n8n-Instanz automatisiert aufsetzbar (Docker Compose, Helm oder Skript) und mit Beispiel-Workflows getestet.
+- [ ] LangChain/n8n-Orchestrierung implementiert, inkl. Webhook/gRPC-Brücken und Fehlertoleranz-Strategie.
+- [ ] CI/CD-Pipeline dokumentiert (GitHub Enterprise + Kubernetes) mit mindestens einem End-to-End-Durchlauf.
+- [ ] Data-Flywheel Mechanismen definiert (Feedbackschleifen, Metriken) und im Monitoring sichtbar gemacht.
+- [ ] Rollback- und Notfallprozesse für Automationen beschrieben und geübt.
+
+## Aura – Monitoring & Dashboard Developer
+- [ ] Grafana Deployment (lokal/Cluster) beschrieben, Dashboards versioniert und wiederholbar installierbar.
+- [ ] LUX-Dashboard Mockups/Wireframes erstellt, mit Datenquellen aus `nova/logging/kpi` verdrahtet.
+- [ ] KPI-Definitionen für Energie- und Ressourceneffizienz inklusive Alert-Grenzwerte dokumentiert.
+- [ ] Emotionale/Stimmungs-Metriken konzipiert, Datenschutz implikationen bewertet und Freigabe eingeholt.
+- [ ] Monitoring-Hooks (Logs, Metriken, Traces) in Testumgebung verifiziert.
+
+> **Hinweis:** Fortschritt wird über Pull Requests nachvollzogen. Jede Rolle aktualisiert die Checkliste in Abstimmung mit den Roadmap-Meilensteinen und verlinkt die relevanten Artefakte.

--- a/docs/next_steps.md
+++ b/docs/next_steps.md
@@ -34,7 +34,7 @@ Dieses Dokument beantwortet die Frage "Wie machen wir jetzt weiter?" und bietet 
 - **Energie- und Stimmungsmetriken:** Sammle Anforderungen und definiere KPIs für Effizienz und Stimmungsfeedback.
 
 ## 7. Organisations- und Governance-Arbeit
-- **Roadmap verfeinern:** Aktualisiere `README.md` bzw. ein neues Roadmap-Dokument mit Milestones, Definition of Done und Verantwortlichen.
+- **Roadmap verfeinern:** Pflege `README.md` und `docs/DEFINITION_OF_DONE.md`, synchronisiere Milestones, Definition of Done und Verantwortlichkeiten.
 - **Teststrategie festlegen:** Lege fest, welche automatisierten Tests pro Modul Pflicht sind (Unit-, Integration- und Systemtests).
 - **Audit-Trail definieren:** Nutze `nova/security` und `nova/monitoring`, um Berichtsprozesse festzuhalten.
 

--- a/progress_report.md
+++ b/progress_report.md
@@ -1,8 +1,8 @@
 # Progress Report
 
-Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 3 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 43 %.
+Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 4 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 57 %.
 
-- Abgeschlossen: "Finalise feature list for v1.0", "Develop agent blueprints and roles", "Implement test harness and monitoring".
-- Offen: Vier weitere Roadmap-Punkte, darunter die Migration zur Spark-Hardware sowie Integrations-, Sicherheits- und Testautomatisierungsaufgaben.
+- Abgeschlossen: "Finalise feature list for v1.0", "Develop agent blueprints and roles", "Implement test harness and monitoring", "Extend roadmap milestones with a Definition of Done per agent role" (Dokumentation in `docs/DEFINITION_OF_DONE.md`).
+- Offen: Drei weitere Roadmap-Punkte, darunter die Migration zur Spark-Hardware sowie Integrations-, Sicherheits- und Testautomatisierungsaufgaben.
 
 Dieser Wert ist eine grobe Näherung, weil keine detaillierteren Statusangaben im Repository vorliegen.


### PR DESCRIPTION
## Summary
- document per-agent definitions of done to clarify exit criteria
- mark the roadmap milestone as complete and reference the new checklist
- update the progress report and next steps guidance to align with the new documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5f646d584832fb7a0edced33ea1b3