### PR TITLE
Add global step plan CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The CLI provides the following subcommands:
 - `orchestrate`: execute every registered agent sequentially using the blueprint specifications. Provide ``--agents`` to limit the set and use ``NOVA_EXECUTION_MODE=parallel`` (or the programmatic API) for concurrent execution.
 - `tasks`: inspect agent assignments or render them as a checklist with ``--checklist``.
 - `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist. Pass `--phase foundation observability` to focus on specific phases.
+- `step-plan`: render an ordered Schritt-für-Schritt-Plan über alle offenen Aufgaben; combine with `--phase` to narrow the focus.
 
 Example workflow:
 
@@ -53,6 +54,7 @@ python -m nova setup --packages docker kubernetes
 python -m nova blueprints
 python -m nova orchestrate
 python -m nova roadmap
+python -m nova step-plan
 ```
 
 ## Task Queue & Microservices

--- a/docs/next_steps.md
+++ b/docs/next_steps.md
@@ -2,6 +2,8 @@
 
 Dieses Dokument beantwortet die Frage "Wie machen wir jetzt weiter?" und bietet einen klaren Fahrplan, um das Nova-Orchestratorsystem strukturiert auszubauen. Die Schritte sind nach Priorität geordnet und referenzieren die vorhandenen Rollenaufgaben aus `TASKS.md`.
 
+> 💡 **Tipp:** Verwende `python -m nova step-plan`, um eine automatisch generierte Schritt-für-Schritt-Liste aus der Aufgabenübersicht (`Agenten_Aufgaben_Uebersicht.csv`) zu erhalten. Über `--phase foundation` lässt sich der Plan auf einzelne Phasen eingrenzen.
+
 ## 1. Infrastruktur-Grundlagen fertigstellen (Nova)
 - **System- und Hardware-Audits abschließen:** Führe die in `nova/system` implementierten Prüf-Utilities aus, um CPU, GPU und Netzwerk zu verifizieren.
 - **Container- und Orchestrierungstools installieren:** Script- oder CLI-Aufrufe für Docker und Kubernetes automatisieren und Ergebnisse dokumentieren.


### PR DESCRIPTION
## Summary
- add a `build_global_step_plan` helper to render a phase-ordered checklist of all tasks
- expose the new plan through a `step-plan` CLI subcommand and reference it in the documentation
- extend the unit tests to cover the new builder and command behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5f7a93428832f966112caff7a499e