### PR TITLE
Add benchmark runner for Spark baseline metrics

### DIFF
--- a/docs/TESTING_MONITORING_REFINEMENT.md
+++ b/docs/TESTING_MONITORING_REFINEMENT.md
@@ -25,8 +25,8 @@ It extends the existing harness in `tests/` and the monitoring utilities under `
   - [ ] Mirror scenarios for Redis backend in `tests/test_task_queue_redis.py` with configurable latency injection.
   - [ ] Create `tests/test_policy_engine.py` to validate allow/deny caches and OPA fallback behaviour using fixtures.
 - [ ] **Performance Benchmarks**
-  - [ ] Implement `nova.monitoring.benchmarks.run_spark_baseline()` to orchestrate GPU, CPU and network measurements.
-  - [ ] Store benchmark artefacts in `nova/logging/kpi` for reuse by dashboards and reports.
+  - [x] Implement `nova.monitoring.benchmarks.run_spark_baseline()` to orchestrate GPU, CPU and network measurements.
+  - [x] Store benchmark artefacts in `nova/logging/kpi` for reuse by dashboards and reports.
   - [ ] Document benchmark execution in `docs/SPARK_MIGRATION_PLAN.md` section 5 upon completion.
 - [ ] **Monitoring Dashboard Enhancements**
   - [ ] Add migration KPI panels (deployment duration, error budgets) to Grafana JSON definitions.

--- a/nova/logging/kpi/__init__.py
+++ b/nova/logging/kpi/__init__.py
@@ -39,6 +39,8 @@ class MetricAggregate:
     def percentile_95(self) -> float:
         if not self.values:
             return 0.0
+        if len(self.values) == 1:
+            return self.values[0]
         return statistics.quantiles(self.values, n=100)[94]
 
 

--- a/nova/monitoring/__init__.py
+++ b/nova/monitoring/__init__.py
@@ -1,5 +1,5 @@
-"""
-Monitoring subpackage for Nova.
+"""Monitoring subpackage for Nova."""
 
-This package contains modules responsible for logging and system monitoring.
-"""
+from .benchmarks import BaselineSnapshot, run_spark_baseline
+
+__all__ = ["BaselineSnapshot", "run_spark_baseline"]

--- a/nova/monitoring/benchmarks.py
+++ b/nova/monitoring/benchmarks.py
@@ -1,0 +1,103 @@
+"""Baseline benchmark helpers for Spark hardware validation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from nova.logging.kpi import KPITracker
+from nova.system.checks import check_cpu, check_gpu, check_network
+
+_DEFAULT_ARTIFACT_DIR = Path(__file__).resolve().parents[1] / "logging" / "kpi"
+
+
+def _serialise_timestamp(dt: datetime) -> tuple[str, str]:
+    """Return ISO timestamp and a filename safe variant."""
+
+    iso_timestamp = dt.isoformat(timespec="seconds")
+    safe_timestamp = iso_timestamp.replace(":", "-")
+    return iso_timestamp, safe_timestamp
+
+
+@dataclass(frozen=True)
+class BaselineSnapshot:
+    """Container holding the results of a baseline benchmark run."""
+
+    timestamp: str
+    cpu: Mapping[str, Any]
+    gpu: Mapping[str, Any]
+    network: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _store_snapshot(
+    snapshot: BaselineSnapshot, output_dir: Path, safe_timestamp: str
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"spark_baseline_{safe_timestamp}.json"
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(snapshot.to_dict(), handle, indent=2, sort_keys=True)
+    return path
+
+
+def _observe_metrics(snapshot: BaselineSnapshot, tracker: KPITracker) -> None:
+    cpu_logical = snapshot.cpu.get("logical_cores")
+    if isinstance(cpu_logical, (int, float)):
+        tracker.observe("cpu.logical_cores", float(cpu_logical))
+
+    gpu_available = snapshot.gpu.get("available")
+    tracker.observe("gpu.available", 1.0 if bool(gpu_available) else 0.0)
+
+    gpu_details = snapshot.gpu.get("details")
+    if isinstance(gpu_details, (list, tuple)):
+        tracker.observe("gpu.devices", float(len(gpu_details)))
+
+    network_online = snapshot.network.get("online")
+    tracker.observe("network.online", 1.0 if bool(network_online) else 0.0)
+
+
+def run_spark_baseline(
+    *,
+    output_dir: Path | str | None = None,
+    tracker: KPITracker | None = None,
+) -> BaselineSnapshot:
+    """Execute CPU, GPU and network checks and persist the measurements.
+
+    Parameters
+    ----------
+    output_dir:
+        Optional directory used to store the generated JSON artefact. Defaults to
+        ``nova/logging/kpi`` when omitted.
+    tracker:
+        Optional :class:`~nova.logging.kpi.KPITracker` that records numeric
+        observations derived from the captured metrics.
+    """
+
+    cpu_info = check_cpu()
+    gpu_info = check_gpu()
+    network_info = check_network()
+
+    timestamp, safe_timestamp = _serialise_timestamp(datetime.now(timezone.utc))
+    snapshot = BaselineSnapshot(
+        timestamp=timestamp,
+        cpu=cpu_info,
+        gpu=gpu_info,
+        network=network_info,
+    )
+
+    artefact_dir = Path(output_dir) if output_dir is not None else _DEFAULT_ARTIFACT_DIR
+    _store_snapshot(snapshot, artefact_dir, safe_timestamp)
+
+    if tracker is not None:
+        _observe_metrics(snapshot, tracker)
+
+    return snapshot
+
+
+__all__ = ["BaselineSnapshot", "run_spark_baseline"]
+

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+from nova.logging.kpi import KPITracker
+from nova.monitoring.benchmarks import run_spark_baseline
+
+
+@pytest.fixture
+def tracker():
+    return KPITracker(namespace="test")
+
+
+def test_run_spark_baseline_records_checks_and_writes(tmp_path, monkeypatch, tracker):
+    cpu_info = {"architecture": "x86_64", "logical_cores": 16, "processor": "Test"}
+    gpu_info = {"available": True, "details": ["GPU 0", "GPU 1"]}
+    network_info = {"online": True, "details": "loopback ok"}
+
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_cpu", lambda: cpu_info)
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_gpu", lambda: gpu_info)
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_network", lambda: network_info)
+
+    snapshot = run_spark_baseline(output_dir=tmp_path, tracker=tracker)
+
+    assert snapshot.cpu == cpu_info
+    assert snapshot.gpu == gpu_info
+    assert snapshot.network == network_info
+
+    artefacts = list(tmp_path.glob("spark_baseline_*.json"))
+    assert len(artefacts) == 1
+
+    with artefacts[0].open(encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    assert data["cpu"] == cpu_info
+    assert data["gpu"] == gpu_info
+    assert data["network"] == network_info
+
+    metrics = tracker.snapshot()["metrics"]
+    assert metrics["cpu.logical_cores"]["mean"] == pytest.approx(16.0)
+    assert metrics["gpu.available"]["mean"] == pytest.approx(1.0)
+    assert metrics["network.online"]["mean"] == pytest.approx(1.0)
+    assert metrics["gpu.devices"]["mean"] == pytest.approx(2.0)
+
+
+def test_run_spark_baseline_handles_missing_metrics(tmp_path, monkeypatch):
+    cpu_info = {"architecture": "arm64", "processor": "Test"}
+    gpu_info = {"available": False, "details": "nvidia-smi executable not found"}
+    network_info = {"online": False, "details": "network error"}
+
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_cpu", lambda: cpu_info)
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_gpu", lambda: gpu_info)
+    monkeypatch.setattr("nova.monitoring.benchmarks.check_network", lambda: network_info)
+
+    snapshot = run_spark_baseline(output_dir=tmp_path)
+
+    assert snapshot.cpu == cpu_info
+    assert snapshot.gpu == gpu_info
+    assert snapshot.network == network_info
+
+    artefacts = list(tmp_path.glob("spark_baseline_*.json"))
+    assert len(artefacts) == 1


### PR DESCRIPTION
## Summary
- implement `run_spark_baseline` benchmark helper that captures CPU, GPU, and network checks while persisting JSON artefacts for dashboards
- expose the benchmark utility via the monitoring package and guard KPI percentile calculations against single-value samples
- cover the workflow with unit tests and mark the performance benchmark checklist items as complete

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e60c23f224832f8ff26e2bb01cb5ee