### PR TITLE
Add concurrency stress coverage for task queue backends

### DIFF
--- a/docs/TESTING_MONITORING_REFINEMENT.md
+++ b/docs/TESTING_MONITORING_REFINEMENT.md
@@ -20,9 +20,9 @@ It extends the existing harness in `tests/` and the monitoring utilities under `
 
 ## 3. Detailed Tasks
 
-- [ ] **Test Harness Hardening**
-  - [ ] Extend `tests/test_task_queue.py` with concurrency stress scenarios (1k jobs, 10 workers).
-  - [ ] Mirror scenarios for Redis backend in `tests/test_task_queue_redis.py` with configurable latency injection.
+- [x] **Test Harness Hardening**
+  - [x] Extend `tests/test_task_queue.py` with concurrency stress scenarios (1k jobs, 10 workers).
+  - [x] Mirror scenarios for Redis backend in `tests/test_task_queue_redis.py` with configurable latency injection.
   - [ ] Create `tests/test_policy_engine.py` to validate allow/deny caches and OPA fallback behaviour using fixtures.
 - [ ] **Performance Benchmarks**
   - [x] Implement `nova.monitoring.benchmarks.run_spark_baseline()` to orchestrate GPU, CPU and network measurements.


### PR DESCRIPTION
## Summary
- add a 1k job concurrency stress test for the gRPC task queue service
- harden the in-memory Redis stub with locking/latency support and exercise it under concurrent load
- mark the roadmap refinement checklist items complete for the new stress scenarios

## Testing
- pytest tests/test_task_queue.py tests/test_task_queue_redis.py

------
https://chatgpt.com/codex/tasks/task_e_68e615c98ce0832f8af722aa7eea5fa0