### PR TITLE
Add Grafana migration dashboard and integration

### DIFF
--- a/docs/SPARK_MIGRATION_PLAN.md
+++ b/docs/SPARK_MIGRATION_PLAN.md
@@ -61,6 +61,10 @@ handoffs and rollback paths.
         die GPU wurde erwartungsgemäß als nicht verfügbar markiert.
 - [ ] Enable Aura's dashboards (Grafana, LUX) to monitor migration KPIs such as
       deployment duration, resource saturation and error budgets. _Due: KW 29_
+      - *Status 2025-10-08:* Grafana-Paneldefinitionen für Deployment-Dauer und
+        Error-Budget-Verbrauch stehen nun unter
+        ``docs/dashboards/spark_migration_grafana.json`` bereit und werden in
+        der Observability-CLI referenziert. Die LUX-Integration folgt.
 - [ ] Collect security and compliance evidence (audit logs, policy decisions)
       to support the scheduled integration and security reviews. _Due: KW 30_
 

--- a/docs/TESTING_MONITORING_REFINEMENT.md
+++ b/docs/TESTING_MONITORING_REFINEMENT.md
@@ -29,7 +29,7 @@ It extends the existing harness in `tests/` and the monitoring utilities under `
   - [x] Store benchmark artefacts in `nova/logging/kpi` for reuse by dashboards and reports.
   - [ ] Document benchmark execution in `docs/SPARK_MIGRATION_PLAN.md` section 5 upon completion.
 - [ ] **Monitoring Dashboard Enhancements**
-  - [ ] Add migration KPI panels (deployment duration, error budgets) to Grafana JSON definitions.
+  - [x] Add migration KPI panels (deployment duration, error budgets) to Grafana JSON definitions (`docs/dashboards/spark_migration_grafana.json`).
   - [ ] Generate a LUX dashboard slice for compliance evidence (audit trail coverage, policy drift).
   - [ ] Link dashboards to review schedule in `docs/INTEGRATION_SECURITY_REVIEWS.md`.
 - [ ] **Alerting Automation**

--- a/docs/dashboards/spark_migration_grafana.json
+++ b/docs/dashboards/spark_migration_grafana.json
@@ -1,0 +1,276 @@
+{
+  "__inputs": [
+    {
+      "description": "Prometheus data source providing Nova KPI metrics.",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus",
+      "type": "datasource"
+    }
+  ],
+  "__requires": [
+    {
+      "id": "grafana",
+      "name": "Grafana",
+      "type": "grafana",
+      "version": "9.5.0"
+    },
+    {
+      "id": "timeseries",
+      "name": "Time series",
+      "type": "panel",
+      "version": "9.5.0"
+    },
+    {
+      "id": "stat",
+      "name": "Stat",
+      "type": "panel",
+      "version": "9.5.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Deployments",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Observability snapshot used by Aura during the Spark migration.",
+  "editable": true,
+  "fiscalYearStartMonth": 1,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 900
+              },
+              {
+                "color": "red",
+                "value": 1200
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg_over_time(nova_deployment_duration_seconds{environment=\"${Environment}\"}[24h])",
+          "legendFormat": "Average",
+          "refId": "A"
+        },
+        {
+          "expr": "max_over_time(nova_deployment_duration_seconds{environment=\"${Environment}\"}[24h])",
+          "legendFormat": "Max",
+          "refId": "B"
+        }
+      ],
+      "title": "Deployment Duration Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(nova_error_budget_consumed{environment=\"${Environment}\"}) / sum(nova_error_budget_total{environment=\"${Environment}\"})) * 100",
+          "legendFormat": "Consumed",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Burn",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "table"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum_over_time(nova_error_budget_remaining{environment=\"${Environment}\"}[1d])",
+          "legendFormat": "Remaining",
+          "refId": "A"
+        }
+      ],
+      "title": "Remaining Error Budget",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "spark-migration",
+    "nova",
+    "aura"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "staging",
+          "value": "staging"
+        },
+        "label": "Environment",
+        "name": "Environment",
+        "options": [
+          {
+            "selected": true,
+            "text": "staging",
+            "value": "staging"
+          },
+          {
+            "selected": false,
+            "text": "production",
+            "value": "production"
+          }
+        ],
+        "query": "staging,production",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ]
+  },
+  "timezone": "",
+  "title": "Spark Migration KPIs",
+  "uid": "spark-migration-kpis",
+  "version": 1,
+  "weekStart": ""
+}

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -20,6 +20,7 @@ from .system.security import run_security_audit
 from .system.orchestrator import Orchestrator
 from .blueprints.generator import create_blueprint, list_available_blueprints
 from .monitoring.alerts import notify_info, notify_warning
+from .monitoring.dashboards import export_migration_dashboard
 from .monitoring.logging import configure_logger, log_error, log_info, log_warning
 from .monitoring.reports import build_markdown_test_report
 from .system.roadmap import (
@@ -123,6 +124,8 @@ def run_monitor() -> None:
 
     configure_logger()
     log_info("Monitoring services initialised.")
+    dashboard_path = export_migration_dashboard()
+    log_info(f"Grafana dashboard exported to {dashboard_path}")
     notify_warning("Monitoring is running in stub mode.")
     notify_info("No active alerts.")
 

--- a/nova/monitoring/__init__.py
+++ b/nova/monitoring/__init__.py
@@ -1,5 +1,16 @@
 """Monitoring subpackage for Nova."""
 
 from .benchmarks import BaselineSnapshot, run_spark_baseline
+from .dashboards import (
+    build_migration_dashboard,
+    export_migration_dashboard,
+    load_migration_dashboard,
+)
 
-__all__ = ["BaselineSnapshot", "run_spark_baseline"]
+__all__ = [
+    "BaselineSnapshot",
+    "run_spark_baseline",
+    "build_migration_dashboard",
+    "export_migration_dashboard",
+    "load_migration_dashboard",
+]

--- a/nova/monitoring/dashboards.py
+++ b/nova/monitoring/dashboards.py
@@ -1,0 +1,260 @@
+"""Utilities for provisioning Grafana dashboards used during the Spark migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DASHBOARD_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "dashboards" / "spark_migration_grafana.json"
+)
+
+
+def _build_timeseries_panel(panel_id: int, *, environment_variable: str) -> dict[str, Any]:
+    """Return the deployment duration panel configuration."""
+
+    return {
+        "id": panel_id,
+        "type": "timeseries",
+        "title": "Deployment Duration Trend",
+        "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}",
+        },
+        "targets": [
+            {
+                "expr": (
+                    "avg_over_time(nova_deployment_duration_seconds"
+                    "{environment=\"${%s}\"}[24h])" % environment_variable
+                ),
+                "legendFormat": "Average",
+                "refId": "A",
+            },
+            {
+                "expr": (
+                    "max_over_time(nova_deployment_duration_seconds"
+                    "{environment=\"${%s}\"}[24h])" % environment_variable
+                ),
+                "legendFormat": "Max",
+                "refId": "B",
+            },
+        ],
+        "fieldConfig": {
+            "defaults": {
+                "unit": "s",
+                "decimals": 2,
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "green", "value": None},
+                        {"color": "yellow", "value": 900},
+                        {"color": "red", "value": 1200},
+                    ],
+                },
+            },
+        },
+        "options": {
+            "legend": {"displayMode": "table"},
+            "tooltip": {"mode": "multi"},
+        },
+        "gridPos": {"h": 9, "w": 24, "x": 0, "y": 0},
+    }
+
+
+def _build_error_budget_panel(panel_id: int, *, environment_variable: str) -> dict[str, Any]:
+    """Return the error budget burn panel configuration."""
+
+    return {
+        "id": panel_id,
+        "type": "stat",
+        "title": "Error Budget Burn",
+        "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}",
+        },
+        "targets": [
+            {
+                "expr": (
+                    "(sum(nova_error_budget_consumed{environment=\"${%s}\"})"
+                    " / sum(nova_error_budget_total{environment=\"${%s}\"}))"
+                    " * 100"
+                )
+                % (environment_variable, environment_variable),
+                "legendFormat": "Consumed",
+                "refId": "A",
+            }
+        ],
+        "fieldConfig": {
+            "defaults": {
+                "unit": "percent",
+                "decimals": 1,
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "green", "value": None},
+                        {"color": "yellow", "value": 50},
+                        {"color": "red", "value": 85},
+                    ],
+                },
+            }
+        },
+        "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": ""},
+            "orientation": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+        },
+        "gridPos": {"h": 6, "w": 12, "x": 0, "y": 9},
+    }
+
+
+def _build_remaining_budget_panel(panel_id: int, *, environment_variable: str) -> dict[str, Any]:
+    """Return the remaining error budget trend panel configuration."""
+
+    return {
+        "id": panel_id,
+        "type": "timeseries",
+        "title": "Remaining Error Budget",
+        "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}",
+        },
+        "targets": [
+            {
+                "expr": (
+                    "sum_over_time(nova_error_budget_remaining"
+                    "{environment=\"${%s}\"}[1d])" % environment_variable
+                ),
+                "legendFormat": "Remaining",
+                "refId": "A",
+            }
+        ],
+        "fieldConfig": {
+            "defaults": {
+                "unit": "percent",
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "red", "value": None},
+                        {"color": "yellow", "value": 25},
+                        {"color": "green", "value": 50},
+                    ],
+                },
+            },
+        },
+        "options": {
+            "legend": {"displayMode": "table"},
+            "tooltip": {"mode": "single"},
+        },
+        "gridPos": {"h": 6, "w": 12, "x": 12, "y": 9},
+    }
+
+
+def build_migration_dashboard(*, refresh: str = "5m") -> dict[str, Any]:
+    """Return the Grafana dashboard definition with migration KPI panels."""
+
+    environment_variable = "Environment"
+    panels = [
+        _build_timeseries_panel(1, environment_variable=environment_variable),
+        _build_error_budget_panel(2, environment_variable=environment_variable),
+        _build_remaining_budget_panel(3, environment_variable=environment_variable),
+    ]
+
+    dashboard: dict[str, Any] = {
+        "__inputs": [
+            {
+                "name": "DS_PROMETHEUS",
+                "label": "Prometheus",
+                "description": "Prometheus data source providing Nova KPI metrics.",
+                "type": "datasource",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus",
+            }
+        ],
+        "__requires": [
+            {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "9.5.0"},
+            {
+                "type": "panel",
+                "id": "timeseries",
+                "name": "Time series",
+                "version": "9.5.0",
+            },
+            {"type": "panel", "id": "stat", "name": "Stat", "version": "9.5.0"},
+        ],
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+                    "enable": True,
+                    "hide": False,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Deployments",
+                    "type": "dashboard",
+                }
+            ]
+        },
+        "description": "Observability snapshot used by Aura during the Spark migration.",
+        "editable": True,
+        "fiscalYearStartMonth": 1,
+        "gnetId": None,
+        "graphTooltip": 0,
+        "id": None,
+        "links": [],
+        "liveNow": False,
+        "panels": panels,
+        "refresh": refresh,
+        "schemaVersion": 38,
+        "style": "dark",
+        "tags": ["spark-migration", "nova", "aura"],
+        "templating": {
+            "list": [
+                {
+                    "name": environment_variable,
+                    "type": "custom",
+                    "label": "Environment",
+                    "query": "staging,production",
+                    "current": {"text": "staging", "value": "staging"},
+                    "options": [
+                        {"text": "staging", "value": "staging", "selected": True},
+                        {"text": "production", "value": "production", "selected": False},
+                    ],
+                }
+            ]
+        },
+        "time": {"from": "now-7d", "to": "now"},
+        "timepicker": {"refresh_intervals": ["5m", "15m", "30m", "1h"]},
+        "timezone": "",
+        "title": "Spark Migration KPIs",
+        "uid": "spark-migration-kpis",
+        "version": 1,
+        "weekStart": "",
+    }
+    return dashboard
+
+
+def export_migration_dashboard(path: Path | str | None = None, *, indent: int = 2) -> Path:
+    """Write the Grafana dashboard definition to ``path`` and return it."""
+
+    target = Path(path) if path is not None else _DEFAULT_DASHBOARD_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    dashboard = build_migration_dashboard()
+    target.write_text(json.dumps(dashboard, indent=indent, sort_keys=True), encoding="utf-8")
+    return target
+
+
+def load_migration_dashboard(path: Path | str | None = None) -> dict[str, Any]:
+    """Load the Grafana dashboard JSON payload from disk."""
+
+    source = Path(path) if path is not None else _DEFAULT_DASHBOARD_PATH
+    data = json.loads(source.read_text(encoding="utf-8"))
+    return data
+
+
+__all__ = [
+    "build_migration_dashboard",
+    "export_migration_dashboard",
+    "load_migration_dashboard",
+]

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nova.monitoring import dashboards as dashboards_module
+from nova.monitoring.dashboards import (
+    build_migration_dashboard,
+    export_migration_dashboard,
+    load_migration_dashboard,
+)
+
+
+def _get_panel(dashboard: dict[str, object], title: str) -> dict[str, object]:
+    panels = dashboard.get("panels", [])
+    assert isinstance(panels, list)
+    for panel in panels:
+        if isinstance(panel, dict) and panel.get("title") == title:
+            return panel
+    raise AssertionError(f"panel '{title}' not found")
+
+
+def test_build_migration_dashboard_contains_expected_panels():
+    dashboard = build_migration_dashboard()
+    assert dashboard["title"] == "Spark Migration KPIs"
+
+    duration_panel = _get_panel(dashboard, "Deployment Duration Trend")
+    targets = duration_panel.get("targets", [])
+    assert any(
+        "nova_deployment_duration_seconds" in target.get("expr", "")
+        for target in targets
+        if isinstance(target, dict)
+    )
+
+    burn_panel = _get_panel(dashboard, "Error Budget Burn")
+    burn_targets = burn_panel.get("targets", [])
+    assert any(
+        "nova_error_budget_consumed" in target.get("expr", "")
+        for target in burn_targets
+        if isinstance(target, dict)
+    )
+
+    remaining_panel = _get_panel(dashboard, "Remaining Error Budget")
+    remaining_targets = remaining_panel.get("targets", [])
+    assert any(
+        "nova_error_budget_remaining" in target.get("expr", "")
+        for target in remaining_targets
+        if isinstance(target, dict)
+    )
+
+
+def test_export_and_load_roundtrip(tmp_path: Path):
+    target = tmp_path / "dashboard.json"
+    exported = export_migration_dashboard(target)
+    assert exported == target
+    payload = json.loads(target.read_text())
+    assert payload["uid"] == "spark-migration-kpis"
+
+    loaded = load_migration_dashboard(target)
+    assert loaded == payload
+
+
+def test_export_uses_default_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    default_path = tmp_path / "spark.json"
+    monkeypatch.setattr(dashboards_module, "_DEFAULT_DASHBOARD_PATH", default_path)
+
+    exported = export_migration_dashboard()
+    assert exported == default_path
+    assert default_path.exists()


### PR DESCRIPTION
## Summary
- add a Spark migration Grafana dashboard template with deployment duration and error budget panels
- expose dashboard build/export helpers via nova.monitoring and export the template from the monitor CLI
- document the new dashboard artefact in the migration and testing refinement plans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e62654b838832fa0e86eceaeda8c41