### PR TITLE
Add agent filtering support to Nova progress CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The CLI provides the following subcommands:
 - `tasks`: inspect agent assignments or render them as a checklist with ``--checklist``.
 - `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist. Pass `--phase foundation observability` to focus on specific phases.
 - `step-plan`: render an ordered Schritt-für-Schritt-Plan über alle offenen Aufgaben; combine with `--phase` to narrow the focus.
-- `progress`: generate an aggregated Fortschrittsbericht with per-agent snapshots and the next pending steps (configure the number of previews with `--limit`).
+- `progress`: generate an aggregated Fortschrittsbericht with per-agent snapshots and the next pending steps (configure the number of previews with `--limit` and focus on specific specialists via `--agent`).
 
 Example workflow:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,3 +178,23 @@ def test_cli_progress_command(tmp_path, monkeypatch, caplog):
     assert "- Gesamtaufgaben: 4" in caplog.text
     assert "### Nächste Schritte" in caplog.text
     assert "- …" in caplog.text
+
+
+def test_cli_progress_with_agent_filter(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),System prüfen,Offen\n"
+        "Nova (Chef-Agentin),Backup,Abgeschlossen\n"
+        "Orion (KI-Software-Spezialist),LLM vorbereiten,Offen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["progress", "--agent", "nova"])
+
+    assert "Loading agent tasks from" in caplog.text
+    assert "- Gesamtaufgaben: 2" in caplog.text
+    assert "## Nova (Chef-Agentin)" in caplog.text
+    assert "## Orion" not in caplog.text


### PR DESCRIPTION
## Summary
- extend the `nova progress` CLI command with an `--agent` filter for targeted reports and warn when no tasks match
- document the new filtering capability in the README
- add regression coverage for filtering via the CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e6318e5d7c832fbae01290258bacf8