### PR TITLE
Add LUX compliance slice and finalize monitoring documentation

### DIFF
--- a/docs/INTEGRATION_SECURITY_REVIEWS.md
+++ b/docs/INTEGRATION_SECURITY_REVIEWS.md
@@ -26,17 +26,18 @@ this document aligns all agent owners on the review cadence, scope and deliverab
 | Foundation | Spark cluster spec sheet, namespace allocation plan, firewall topology draft. | Signed-off infrastructure checklist, risk register updates. |
 | Intelligence | LLM deployment plan, data migration runbook, encryption baselines. | Approved data handling policy, outstanding model validation issues. |
 | Interaction | Avatar integration diagram, workflow API tests, user journey storyboard. | Integration sign-off, UI/UX action list, automation backlog entries. |
-| Cut-over | Final migration rehearsal report, rollback procedure, support schedule. | Production go/no-go decision, final compliance attestation. |
+| Cut-over | Final migration rehearsal report, rollback procedure, support schedule. | Production go/no-go decision, final compliance attestation incl. LUX compliance slice export. |
 
 ## 4. Communication & Tracking
 
 - Meeting invites distributed via shared calendar with agenda at least 72 h in advance.
 - Decisions and open issues tracked in the orchestration journal with cross-links to `docs/SPARK_MIGRATION_PLAN.md` tasks.
 - Escalations route to the Nova steering committee when blockers exceed 3 business days without mitigation.
+- Dashboard references: Grafana KPI export under `docs/dashboards/spark_migration_grafana.json`, LUX compliance evidence slice under `docs/dashboards/lux_compliance_slice.json` (mirrors audit trail coverage & policy drift per review window).
 
 ## 5. Next Actions
 
 1. ✅ Confirmed review slots with all participants (calendar invitations sent 2024-06-11).
 2. ✅ Security Manager mapped checklist templates to OPA policy audit trail (stored in `nova/security`).
 3. 🔄 Chronos to automate evidence export from the test harness before KW 26 review.
-4. 🔄 Aura to prepare compliance reporting dashboard slice (Grafana) ahead of KW 27 session.
+4. ✅ Aura prepared compliance reporting dashboard slice (LUX) ahead of KW 27 session – see `docs/dashboards/lux_compliance_slice.json` and `nova/__main__.py::run_monitor` export hook.

--- a/docs/SPARK_MIGRATION_PLAN.md
+++ b/docs/SPARK_MIGRATION_PLAN.md
@@ -59,12 +59,19 @@ handoffs and rollback paths.
         ``nova/logging/kpi/spark_baseline_2025-10-08T07-33-58+00-00.json``. Die
         Ergebnisse bestätigen funktionierende CPU-, GPU- und Netzwerkchecks;
         die GPU wurde erwartungsgemäß als nicht verfügbar markiert.
-- [ ] Enable Aura's dashboards (Grafana, LUX) to monitor migration KPIs such as
+      - Ausführung via ``python -m nova.monitoring.benchmarks``. Der Lauf
+        erstellt automatisch KPI-Schnappschüsse, schreibt sie nach
+        ``nova/logging/kpi`` und aktualisiert den KPI-Tracker für weitere
+        Dashboards.
+- [x] Enable Aura's dashboards (Grafana, LUX) to monitor migration KPIs such as
       deployment duration, resource saturation and error budgets. _Due: KW 29_
       - *Status 2025-10-08:* Grafana-Paneldefinitionen für Deployment-Dauer und
         Error-Budget-Verbrauch stehen nun unter
         ``docs/dashboards/spark_migration_grafana.json`` bereit und werden in
-        der Observability-CLI referenziert. Die LUX-Integration folgt.
+        der Observability-CLI referenziert.
+      - LUX-Compliance-Slice als Evidenzpaket: ``docs/dashboards/lux_compliance_slice.json``
+        verbindet Audit-Trail-Abdeckung und Policy-Drift mit den Review-Fenstern
+        aus ``docs/INTEGRATION_SECURITY_REVIEWS.md``.
 - [ ] Collect security and compliance evidence (audit logs, policy decisions)
       to support the scheduled integration and security reviews. _Due: KW 30_
 

--- a/docs/TESTING_MONITORING_REFINEMENT.md
+++ b/docs/TESTING_MONITORING_REFINEMENT.md
@@ -24,14 +24,14 @@ It extends the existing harness in `tests/` and the monitoring utilities under `
   - [x] Extend `tests/test_task_queue.py` with concurrency stress scenarios (1k jobs, 10 workers).
   - [x] Mirror scenarios for Redis backend in `tests/test_task_queue_redis.py` with configurable latency injection.
   - [x] Create `tests/test_policy_engine.py` to validate allow/deny caches and OPA fallback behaviour using fixtures.
-- [ ] **Performance Benchmarks**
+- [x] **Performance Benchmarks**
   - [x] Implement `nova.monitoring.benchmarks.run_spark_baseline()` to orchestrate GPU, CPU and network measurements.
   - [x] Store benchmark artefacts in `nova/logging/kpi` for reuse by dashboards and reports.
-  - [ ] Document benchmark execution in `docs/SPARK_MIGRATION_PLAN.md` section 5 upon completion.
-- [ ] **Monitoring Dashboard Enhancements**
+  - [x] Document benchmark execution in `docs/SPARK_MIGRATION_PLAN.md` section 5 upon completion (incl. CLI workflow and artefact reference).
+- [x] **Monitoring Dashboard Enhancements**
   - [x] Add migration KPI panels (deployment duration, error budgets) to Grafana JSON definitions (`docs/dashboards/spark_migration_grafana.json`).
-  - [ ] Generate a LUX dashboard slice for compliance evidence (audit trail coverage, policy drift).
-  - [ ] Link dashboards to review schedule in `docs/INTEGRATION_SECURITY_REVIEWS.md`.
+  - [x] Generate a LUX dashboard slice for compliance evidence (audit trail coverage, policy drift) and version it at `docs/dashboards/lux_compliance_slice.json`.
+  - [x] Link dashboards to review schedule in `docs/INTEGRATION_SECURITY_REVIEWS.md`.
 - [ ] **Alerting Automation**
   - [x] Define KPI thresholds inside `nova/logging/kpi/thresholds.yaml`.
   - [x] Wire KPI breaches to PagerDuty/webhook integration script under `nova/monitoring/alerts.py`.

--- a/docs/dashboards/lux_compliance_slice.json
+++ b/docs/dashboards/lux_compliance_slice.json
@@ -1,0 +1,98 @@
+{
+  "data_sources": {
+    "compliance_store": {
+      "name": "nova-compliance-registry",
+      "path": "nova/security/compliance_store.parquet",
+      "refresh_interval": "24h",
+      "type": "parquet"
+    },
+    "policy_registry": {
+      "name": "opa-policy-registry",
+      "path": "nova/policy/cache/decision_log.json",
+      "refresh_interval": "1h",
+      "type": "json"
+    }
+  },
+  "description": "Curated evidence package combining audit trail coverage, policy drift observability and review readiness for Spark migration governance.",
+  "id": "lux-compliance-evidence",
+  "layout": [
+    {
+      "h": 4,
+      "w": 6,
+      "widget": "audit-trail-coverage",
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "w": 6,
+      "widget": "policy-drift-trend",
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "w": 12,
+      "widget": "review-readiness",
+      "x": 0,
+      "y": 4
+    }
+  ],
+  "title": "Spark Migration Compliance Evidence",
+  "widgets": [
+    {
+      "description": "Share of orchestrated events backed by audit artefacts.",
+      "format": "percent",
+      "id": "audit-trail-coverage",
+      "metric": "audit_trail.coverage",
+      "source": "compliance_store",
+      "thresholds": {
+        "critical": 80,
+        "warning": 90
+      },
+      "title": "Audit Trail Coverage",
+      "type": "gauge"
+    },
+    {
+      "description": "OPA decision drift compared to approved baselines (0 = aligned).",
+      "format": "ratio",
+      "id": "policy-drift-trend",
+      "metric": "opa.policy_drift_score",
+      "source": "policy_registry",
+      "thresholds": {
+        "critical": 0.4,
+        "warning": 0.2
+      },
+      "title": "Policy Drift",
+      "type": "sparkline"
+    },
+    {
+      "description": "Maps compliance KPIs to the integration & security review cadence so Aura can confirm evidence before each gate.",
+      "id": "review-readiness",
+      "items": [
+        {
+          "acceptance_criteria": ">= 95% coverage",
+          "label": "KW 26 \u2013 Foundation Review",
+          "status_metric": "audit_trail.coverage"
+        },
+        {
+          "acceptance_criteria": ">= 95% coverage",
+          "label": "KW 27 \u2013 Intelligence Review",
+          "status_metric": "audit_trail.coverage"
+        },
+        {
+          "acceptance_criteria": ">= 95% coverage",
+          "label": "KW 28 \u2013 Interaction Review",
+          "status_metric": "audit_trail.coverage"
+        },
+        {
+          "acceptance_criteria": ">= 95% coverage",
+          "label": "KW 31 \u2013 Cut-over Review",
+          "status_metric": "audit_trail.coverage"
+        }
+      ],
+      "title": "Review Readiness Checklist",
+      "type": "timeline"
+    }
+  ]
+}

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -20,7 +20,10 @@ from .system.security import run_security_audit
 from .system.orchestrator import Orchestrator
 from .blueprints.generator import create_blueprint, list_available_blueprints
 from .monitoring.alerts import notify_info, notify_warning
-from .monitoring.dashboards import export_migration_dashboard
+from .monitoring.dashboards import (
+    export_lux_compliance_slice,
+    export_migration_dashboard,
+)
 from .monitoring.logging import configure_logger, log_error, log_info, log_warning
 from .monitoring.reports import build_markdown_test_report
 from .system.roadmap import (
@@ -126,6 +129,8 @@ def run_monitor() -> None:
     log_info("Monitoring services initialised.")
     dashboard_path = export_migration_dashboard()
     log_info(f"Grafana dashboard exported to {dashboard_path}")
+    lux_path = export_lux_compliance_slice()
+    log_info(f"LUX compliance slice exported to {lux_path}")
     notify_warning("Monitoring is running in stub mode.")
     notify_info("No active alerts.")
 

--- a/nova/monitoring/__init__.py
+++ b/nova/monitoring/__init__.py
@@ -2,15 +2,21 @@
 
 from .benchmarks import BaselineSnapshot, run_spark_baseline
 from .dashboards import (
+    build_lux_compliance_slice,
     build_migration_dashboard,
+    export_lux_compliance_slice,
     export_migration_dashboard,
+    load_lux_compliance_slice,
     load_migration_dashboard,
 )
 
 __all__ = [
     "BaselineSnapshot",
     "run_spark_baseline",
+    "build_lux_compliance_slice",
     "build_migration_dashboard",
+    "export_lux_compliance_slice",
     "export_migration_dashboard",
+    "load_lux_compliance_slice",
     "load_migration_dashboard",
 ]

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -7,8 +7,11 @@ import pytest
 
 from nova.monitoring import dashboards as dashboards_module
 from nova.monitoring.dashboards import (
+    build_lux_compliance_slice,
     build_migration_dashboard,
+    export_lux_compliance_slice,
     export_migration_dashboard,
+    load_lux_compliance_slice,
     load_migration_dashboard,
 )
 
@@ -67,5 +70,38 @@ def test_export_uses_default_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(dashboards_module, "_DEFAULT_DASHBOARD_PATH", default_path)
 
     exported = export_migration_dashboard()
+    assert exported == default_path
+    assert default_path.exists()
+
+
+def test_build_lux_slice_contains_expected_widgets():
+    payload = build_lux_compliance_slice()
+    assert payload["id"] == "lux-compliance-evidence"
+    widget_ids = {widget["id"] for widget in payload["widgets"]}
+    assert {"audit-trail-coverage", "policy-drift-trend", "review-readiness"} <= widget_ids
+
+    coverage_widget = next(widget for widget in payload["widgets"] if widget["id"] == "audit-trail-coverage")
+    assert coverage_widget["type"] == "gauge"
+    assert coverage_widget["metric"] == "audit_trail.coverage"
+
+    drift_widget = next(widget for widget in payload["widgets"] if widget["id"] == "policy-drift-trend")
+    assert drift_widget["thresholds"]["critical"] == 0.4
+
+
+def test_export_and_load_lux_slice(tmp_path: Path):
+    target = tmp_path / "lux_slice.json"
+    exported = export_lux_compliance_slice(target)
+    assert exported == target
+    payload = json.loads(target.read_text())
+    assert payload["title"].startswith("Spark Migration Compliance")
+    loaded = load_lux_compliance_slice(target)
+    assert loaded == payload
+
+
+def test_export_lux_uses_default_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    default_path = tmp_path / "lux.json"
+    monkeypatch.setattr(dashboards_module, "_DEFAULT_LUX_SLICE_PATH", default_path)
+
+    exported = export_lux_compliance_slice()
     assert exported == default_path
     assert default_path.exists()


### PR DESCRIPTION
## Summary
- add a LUX compliance evidence slice alongside the Grafana migration dashboard and expose it via the CLI monitor command
- version the LUX slice JSON asset and extend dashboard tests to cover export/load behaviour
- document the completed benchmark run and link the dashboard assets across the migration and review plans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6387c7668832f9f303fa77b539064