### PR TITLE
Show all pending tasks by default in progress reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The CLI provides the following subcommands:
 - `tasks`: inspect agent assignments or render them as a checklist with ``--checklist``.
 - `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist. Pass `--phase foundation observability` to focus on specific phases.
 - `step-plan`: render an ordered Schritt-für-Schritt-Plan über alle offenen Aufgaben; combine with `--phase` to narrow the focus.
-- `progress`: generate an aggregated Fortschrittsbericht with per-agent snapshots and the next pending steps (configure the number of previews with `--limit` and focus on specific specialists via `--agent`).
+- `progress`: generate an aggregated Fortschrittsbericht with per-agent snapshots and the next pending steps (optionally cap the previews with `--limit`; by default all open To-dos are shown; focus on specific specialists via `--agent`).
 
 Example workflow:
 

--- a/nova/__main__.py
+++ b/nova/__main__.py
@@ -277,7 +277,7 @@ def run_progress(
     csv_path: Path | None = None,
     agent_filters: Iterable[str] | None = None,
     *,
-    pending_limit: int = 3,
+    pending_limit: int | None = None,
 ) -> None:
     """Render the aggregated progress snapshot."""
 
@@ -454,8 +454,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit",
         type=int,
         metavar="N",
-        default=3,
-        help="Number of pending tasks to show per agent (0 for unlimited).",
+        default=None,
+        help=(
+            "Number of pending tasks to show per agent (omit or 0 for unlimited)."
+        ),
     )
 
     return parser

--- a/nova/system/progress.py
+++ b/nova/system/progress.py
@@ -16,7 +16,7 @@ def _percentage(completed: int, total: int) -> int:
 
 
 def _render_pending_tasks(
-    tasks: Sequence[AgentTask], pending_limit: int
+    tasks: Sequence[AgentTask], pending_limit: int | None
 ) -> list[str]:
     """Render a bullet list of pending tasks constrained by ``pending_limit``."""
 
@@ -25,7 +25,7 @@ def _render_pending_tasks(
         return ["Alle Aufgaben abgeschlossen. ✅"]
 
     lines = ["### Nächste Schritte"]
-    if pending_limit <= 0:
+    if pending_limit is None or pending_limit <= 0:
         selected = list(pending)
     else:
         selected = list(pending[:pending_limit])
@@ -42,7 +42,7 @@ def _render_pending_tasks(
 
 
 def build_progress_report(
-    tasks: Sequence[AgentTask], *, pending_limit: int = 3
+    tasks: Sequence[AgentTask], *, pending_limit: int | None = None
 ) -> str:
     """Return a Markdown progress snapshot for ``tasks``."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,6 +180,23 @@ def test_cli_progress_command(tmp_path, monkeypatch, caplog):
     assert "- …" in caplog.text
 
 
+def test_cli_progress_default_shows_all_tasks(tmp_path, monkeypatch, caplog):
+    csv_path = tmp_path / "tasks.csv"
+    csv_path.write_text(
+        "Agenten-Name,Aufgabe,Status\n"
+        "Nova (Chef-Agentin),System prüfen,Offen\n"
+        "Nova (Chef-Agentin),Backup,Offen\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NOVA_TASK_CSV", str(csv_path))
+
+    caplog.set_level("INFO", logger="nova.monitoring")
+    __main__.main(["progress"])
+
+    assert caplog.text.count("- [ ]") == 2
+    assert "weitere Aufgabe" not in caplog.text
+
+
 def test_cli_progress_with_agent_filter(tmp_path, monkeypatch, caplog):
     csv_path = tmp_path / "tasks.csv"
     csv_path.write_text(

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -71,6 +71,24 @@ def test_progress_report_limit_zero_includes_all_pending():
     assert "weitere Aufgabe" not in report
 
 
+def test_progress_report_default_includes_all_pending():
+    tasks = [
+        _task("nova", "Nova (Chef-Agentin)", "Chef-Agentin", "System prüfen", "Offen"),
+        _task(
+            "nova",
+            "Nova (Chef-Agentin)",
+            "Chef-Agentin",
+            "Dokumentation aktualisieren",
+            "Offen",
+        ),
+    ]
+
+    report = build_progress_report(tasks)
+
+    assert report.count("- [ ]") == 2
+    assert "weitere Aufgabe" not in report
+
+
 def test_progress_report_without_tasks_returns_placeholder():
     report = build_progress_report([], pending_limit=2)
     assert report == "# Nova Fortschrittsbericht\n\nKeine Aufgaben gefunden."


### PR DESCRIPTION
## Summary
- default the progress report helper and CLI to display all pending tasks when no limit is provided
- adjust the CLI help text and README to document the updated behaviour
- add unit tests for the unlimited default in both the report helper and CLI entry point

## Testing
- pytest -q
- python -m nova progress


------
https://chatgpt.com/codex/tasks/task_e_68e63c26217c832fa4d27a5b6d6f529f