### PR TITLE
Finalize alerting automation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ python -m nova progress
 - Prepare migration to Spark hardware. ✅ (See `docs/SPARK_MIGRATION_PLAN.md`.)
 - Schedule early integration and security reviews for each milestone to minimise rework. ✅ (See `docs/INTEGRATION_SECURITY_REVIEWS.md`.)
 - Extend roadmap milestones with a "Definition of Done" per agent role to keep progress measurable. ✅ (See `docs/DEFINITION_OF_DONE.md`.)
-- Refine automated testing and monitoring pipelines in parallel to maintain endgame stability. 🚧 (See `docs/TESTING_MONITORING_REFINEMENT.md`.)
+- Refine automated testing and monitoring pipelines in parallel to maintain endgame stability. ✅ (See `docs/TESTING_MONITORING_REFINEMENT.md`.)
 
 ## Contributing
 

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -46,7 +46,7 @@ Dieses Dokument konkretisiert die Qualitätskriterien, die erfüllt sein müssen
 ## Aura – Monitoring & Dashboard Developer
 - [ ] Grafana Deployment (lokal/Cluster) beschrieben, Dashboards versioniert und wiederholbar installierbar.
 - [ ] LUX-Dashboard Mockups/Wireframes erstellt, mit Datenquellen aus `nova/logging/kpi` verdrahtet.
-- [ ] KPI-Definitionen für Energie- und Ressourceneffizienz inklusive Alert-Grenzwerte dokumentiert.
+- [x] KPI-Definitionen für Energie- und Ressourceneffizienz inklusive Alert-Grenzwerte dokumentiert (`nova/logging/kpi/thresholds.yaml`, `docs/TESTING_MONITORING_REFINEMENT.md`).
 - [ ] Emotionale/Stimmungs-Metriken konzipiert, Datenschutz implikationen bewertet und Freigabe eingeholt.
 - [ ] Monitoring-Hooks (Logs, Metriken, Traces) in Testumgebung verifiziert.
 

--- a/docs/TESTING_MONITORING_REFINEMENT.md
+++ b/docs/TESTING_MONITORING_REFINEMENT.md
@@ -32,10 +32,11 @@ It extends the existing harness in `tests/` and the monitoring utilities under `
   - [x] Add migration KPI panels (deployment duration, error budgets) to Grafana JSON definitions (`docs/dashboards/spark_migration_grafana.json`).
   - [x] Generate a LUX dashboard slice for compliance evidence (audit trail coverage, policy drift) and version it at `docs/dashboards/lux_compliance_slice.json`.
   - [x] Link dashboards to review schedule in `docs/INTEGRATION_SECURITY_REVIEWS.md`.
-- [ ] **Alerting Automation**
+- [x] **Alerting Automation**
   - [x] Define KPI thresholds inside `nova/logging/kpi/thresholds.yaml`.
   - [x] Wire KPI breaches to PagerDuty/webhook integration script under `nova/monitoring/alerts.py`.
   - [x] Simulate alert run via `python -m nova.monitoring.alerts --dry-run` and attach output to the orchestration journal (dry run mode now emits structured payload logs for inclusion).
+  - [x] Provide `nova alerts` CLI entry point with optional Markdown export for journal hand-off.
 
 ## 4. Metrics & Reporting
 

--- a/progress_report.md
+++ b/progress_report.md
@@ -2,7 +2,7 @@
 
 > 💡 **Hinweis:** Der Fortschritt lässt sich jetzt direkt über die CLI abrufen: `python -m nova progress` erzeugt einen aktuellen Bericht inklusive nächster Schritte je Agent.
 
-Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell 5 von 7 Meilensteinen als abgeschlossen markiert (✅). Daraus ergibt sich ein geschätzter Fortschritt von rund 71 %.
+Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell alle 7 Meilensteine als abgeschlossen markiert (✅). Damit liegt der Roadmap-Fortschritt bei 100 %.
 
 ## Aktueller CLI-Snapshot (`python -m nova progress`)
 
@@ -22,6 +22,7 @@ Der jüngste CLI-Lauf zeigt nach dem ausgeführten `python -m nova setup`-Durchl
 - **Aura (Monitoring & Dashboard-Entwicklerin):** 4 Aufgaben offen – Grafana, Dashboard, Effizienz- und Sentiment-Metriken.
 
 > ℹ️ Verwende `python -m nova progress --limit 1`, um für jeden Agenten einen schnellen Überblick über die nächsten konkreten To-dos zu erhalten.
+> 🆕 Alert-Dry-Runs können jetzt über `python -m nova alerts --dry-run --export orchestration_journal/alerts.md` dokumentiert werden. Die Markdown-Ausgabe eignet sich für die Übergabe in das Orchestrierungstagebuch.
 
 ## Status nach Roadmap-Meilensteinen
 
@@ -31,7 +32,7 @@ Der jüngste CLI-Lauf zeigt nach dem ausgeführten `python -m nova setup`-Durchl
 - [x] Extend roadmap milestones with a Definition of Done per agent role (Dokumentation in `docs/DEFINITION_OF_DONE.md`).
 - [x] Prepare migration to Spark hardware (`docs/SPARK_MIGRATION_PLAN.md`).
 - [x] Schedule early integration and security reviews für jede Phase (`docs/INTEGRATION_SECURITY_REVIEWS.md`).
-- [ ] Refine automated testing and monitoring pipelines für die Endphase.
+- [x] Refine automated testing and monitoring pipelines für die Endphase (`docs/TESTING_MONITORING_REFINEMENT.md`).
 
 Dieser Wert ist eine grobe Näherung, weil keine detaillierteren Statusangaben im Repository vorliegen.
 

--- a/tests/test_monitoring_alerts.py
+++ b/tests/test_monitoring_alerts.py
@@ -1,0 +1,88 @@
+"""Tests for nova.monitoring.alerts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nova.monitoring import alerts
+
+
+def _sample_thresholds() -> dict:
+    return {
+        "counters": {"queue.failures": {"warning": 2, "critical": 4}},
+        "metrics": {
+            "queue.latency": {"field": "p95", "warning": 100, "critical": 150}
+        },
+    }
+
+
+def test_build_dry_run_snapshot_exceeds_thresholds():
+    thresholds = _sample_thresholds()
+    snapshot = alerts.build_dry_run_snapshot(thresholds)
+
+    assert snapshot["counters"]["queue.failures"] > thresholds["counters"]["queue.failures"]["critical"]
+    assert (
+        snapshot["metrics"]["queue.latency"]["p95"]
+        > thresholds["metrics"]["queue.latency"]["critical"]
+    )
+
+
+def test_render_alert_report_contains_event_details():
+    event = alerts.AlertEvent(
+        severity="critical",
+        metric="queue.latency",
+        value=175.0,
+        threshold=150.0,
+        field="p95",
+        channel="pagerduty",
+    )
+    snapshot = {
+        "counters": {"queue.failures": 5},
+        "metrics": {"queue.latency": {"p95": 175.0, "count": 10}},
+    }
+
+    report = alerts.render_alert_report([event], dry_run=True, snapshot=snapshot)
+
+    assert "# Nova Alert Evaluation" in report
+    assert "queue.latency" in report
+    assert "p95" in report
+    assert "Grenzwert" in report
+
+
+def test_export_alert_report_writes_markdown(tmp_path: Path):
+    event = alerts.AlertEvent(
+        severity="warning",
+        metric="queue.failures",
+        value=6.0,
+        threshold=2.0,
+        field="count",
+        channel="pagerduty",
+    )
+    export_path = tmp_path / "alert.md"
+
+    result_path = alerts.export_alert_report([event], output_path=export_path, dry_run=False)
+
+    assert result_path == export_path.resolve()
+    content = export_path.read_text(encoding="utf-8")
+    assert "Ausgelöste Alerts" in content
+    assert "queue.failures" in content
+
+
+def test_execute_alert_workflow_dry_run_exports_report(tmp_path: Path):
+    thresholds_path = tmp_path / "thresholds.json"
+    thresholds_path.write_text(json.dumps(_sample_thresholds()), encoding="utf-8")
+    export_path = tmp_path / "journal" / "alerts.md"
+
+    events = alerts.execute_alert_workflow(
+        thresholds_path=thresholds_path,
+        snapshot_path=None,
+        dry_run=True,
+        export_path=export_path,
+    )
+
+    assert events, "Dry-run evaluation should create synthetic breaches."
+    assert export_path.exists()
+    markdown = export_path.read_text(encoding="utf-8")
+    assert "Nova Alert Evaluation" in markdown
+


### PR DESCRIPTION
## Summary
- add structured alert workflow helpers that export Markdown reports and share dry-run payloads
- wire a new `nova alerts` CLI command to drive alert evaluations and optional journal exports
- document the completed alerting milestone across the roadmap status reports and definition of done
- add unit coverage for alert snapshot generation, report rendering and export helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e67866fed8832f8727f71f90c9c847