### PR TITLE
Preserve CSV-defined order in Nova step plan

### DIFF
--- a/nova/system/roadmap.py
+++ b/nova/system/roadmap.py
@@ -283,15 +283,16 @@ def build_global_step_plan(
 
     tasks_by_agent: dict[str, list[AgentTask]] = {}
     metadata: dict[str, tuple[str, str | None]] = {}
+    agent_order: list[str] = []
     for task in tasks:
-        tasks_by_agent.setdefault(task.agent_identifier, []).append(task)
+        if task.agent_identifier not in tasks_by_agent:
+            tasks_by_agent[task.agent_identifier] = []
+            agent_order.append(task.agent_identifier)
+        tasks_by_agent[task.agent_identifier].append(task)
         metadata.setdefault(
             task.agent_identifier,
             (task.agent_display_name, task.agent_role),
         )
-
-    for agent_tasks in tasks_by_agent.values():
-        agent_tasks.sort(key=lambda task: task.description.lower())
 
     step = 1
     seen_agents: set[str] = set()
@@ -328,7 +329,7 @@ def build_global_step_plan(
             seen_agents.add(agent_id)
 
     remaining_agents: list[str] = []
-    for agent_id in sorted(tasks_by_agent):
+    for agent_id in agent_order:
         if agent_id in seen_agents:
             continue
         if agent_id in selected_phase_agent_ids:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,8 +176,8 @@ def test_cli_step_plan_command(tmp_path, monkeypatch, caplog):
     __main__.main(["step-plan"])
 
     assert "Nova Schritt-für-Schritt Plan" in caplog.text
-    assert "1. [x] Backup (Status: Abgeschlossen)" in caplog.text
-    assert "2. [ ] System prüfen (Status: Offen)" in caplog.text
+    assert "1. [ ] System prüfen (Status: Offen)" in caplog.text
+    assert "2. [x] Backup (Status: Abgeschlossen)" in caplog.text
     assert "LLM vorbereiten" in caplog.text
     assert "Abstimmung" in caplog.text
 

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -161,8 +161,8 @@ def test_build_global_step_plan_includes_all_statuses():
 
     assert "# Nova Schritt-für-Schritt Plan" in plan_markdown
     assert "- Gesamtaufgaben: 5" in plan_markdown
-    assert "1. [x] Backup einrichten (Status: Abgeschlossen)" in plan_markdown
-    assert "2. [ ] System prüfen (Status: Offen)" in plan_markdown
+    assert "1. [ ] System prüfen (Status: Offen)" in plan_markdown
+    assert "2. [x] Backup einrichten (Status: Abgeschlossen)" in plan_markdown
     assert "3. [ ] LLM vorbereiten (Status: In Arbeit)" in plan_markdown
     assert "Abstimmung" in plan_markdown
 


### PR DESCRIPTION
## Summary
- ensure the global step plan follows the CSV-defined ordering per agent
- keep remaining-agent handling stable by respecting the first-seen order
- update CLI and roadmap tests to assert the new ordering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e67a521e24832f8a18ee0f567cf8ed