### PR TITLE
Add executive roadmap summary command to Nova CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The CLI provides the following subcommands:
 - `roadmap`: create a phase-orientated progress report that highlights the remaining steps for each specialist. Pass `--phase foundation observability` to focus on specific phases.
 - `step-plan`: render an ordered Schritt-für-Schritt-Plan über alle offenen Aufgaben; combine with `--phase` to narrow the focus.
 - `progress`: generate an aggregated Fortschrittsbericht with per-agent snapshots and the next pending steps (optionally cap the previews with `--limit`; by default all open To-dos are shown; focus on specific specialists via `--agent`).
+- `summary`: produce a kompakte Roadmap-Zusammenfassung mit Phasenfortschritt und den wichtigsten nächsten Aufgaben je Agent (limitierbar über `--limit`).
 
 Example workflow:
 

--- a/docs/next_steps_overview.md
+++ b/docs/next_steps_overview.md
@@ -26,4 +26,4 @@ Diese Übersicht fasst die priorisierten Folgeaktivitäten für Meta-Agent Nova 
 - [ ] Roadmap, Definition-of-Done und Teststrategie regelmäßig aktualisieren.
 - [ ] Sprint-Board anlegen, Kick-off organisieren und Minimalziel (Systemchecks + Docker + Logging) starten.
 
-> 📌 Nutze `python -m nova step-plan` und `python -m nova progress`, um den aktuellen Status je Agentenrolle zu verfolgen.
+> 📌 Nutze `python -m nova step-plan`, `python -m nova summary` und `python -m nova progress`, um den aktuellen Status je Agentenrolle zu verfolgen.

--- a/progress_report.md
+++ b/progress_report.md
@@ -1,6 +1,6 @@
 # Progress Report
 
-> 💡 **Hinweis:** Der Fortschritt lässt sich jetzt direkt über die CLI abrufen: `python -m nova progress` erzeugt einen aktuellen Bericht inklusive nächster Schritte je Agent.
+> 💡 **Hinweis:** Der Fortschritt lässt sich jetzt direkt über die CLI abrufen: `python -m nova summary` liefert eine kompakte Roadmap-Übersicht und `python -m nova progress` erzeugt einen detaillierten Bericht inklusive nächster Schritte je Agent.
 
 Basierend auf dem Abschnitt **Roadmap** in der `README.md` sind aktuell alle 7 Meilensteine als abgeschlossen markiert (✅). Damit liegt der Roadmap-Fortschritt bei 100 %.
 


### PR DESCRIPTION
## Summary
- add an executive roadmap summary builder that aggregates phase progress and next steps
- expose the new report through a `python -m nova summary` CLI command and document it in the roadmap guides
- extend the CLI test suite to cover the summary workflow

## Testing
- pytest
- python -m nova summary --limit 1

------
https://chatgpt.com/codex/tasks/task_e_68e67d645390832fa76b0d46b2c10392